### PR TITLE
Deploy: arm the Growatt controller (brain rename + controller scaffolding + 2 pre-flight fixes)

### DIFF
--- a/controllers/growatt/src/config.rs
+++ b/controllers/growatt/src/config.rs
@@ -31,6 +31,11 @@ pub struct GrowattConfig {
     pub battery_power_max_kw: f64,
     #[serde(default = "default_powerrate_step_pct")]
     pub powerrate_step_pct: f64,
+    /// Minimum charge/discharge `powerrate` percent for an active slot. The inverter NAKs (no ack) a
+    /// rate below its minimum, so a nonzero setpoint floors here — mirrors loxone's
+    /// `min_charge_power_rate` (25%). Below this the inverter would reject the command silently.
+    #[serde(default = "default_min_powerrate_pct")]
+    pub min_powerrate_pct: f64,
     #[serde(default = "default_battery_capacity_kwh")]
     pub battery_capacity_kwh: f64,
     /// Local civil-time offset from UTC (for the inverter slot's wall-clock window).
@@ -71,6 +76,7 @@ impl GrowattConfig {
             command_base: self.command_base.clone(),
             battery_power_max_kw: self.battery_power_max_kw,
             powerrate_step_pct: self.powerrate_step_pct,
+            min_powerrate_pct: self.min_powerrate_pct,
             battery_capacity_kwh: self.battery_capacity_kwh,
         }
     }
@@ -93,6 +99,9 @@ fn default_battery_power_max_kw() -> f64 {
 }
 fn default_powerrate_step_pct() -> f64 {
     1.0
+}
+fn default_min_powerrate_pct() -> f64 {
+    25.0 // loxone's min_charge_power_rate default; the inverter NAKs anything lower
 }
 fn default_battery_capacity_kwh() -> f64 {
     10.0

--- a/controllers/growatt/src/translate.rs
+++ b/controllers/growatt/src/translate.rs
@@ -20,6 +20,9 @@ pub struct TranslateCfg {
     pub battery_power_max_kw: f64,
     /// `powerrate` quantization step (percent); the inverter takes integer percent.
     pub powerrate_step_pct: f64,
+    /// Minimum `powerrate` percent for an active slot (the inverter NAKs anything lower) — loxone's
+    /// `min_charge_power_rate`, 25%.
+    pub min_powerrate_pct: f64,
     /// Battery usable capacity (kWh) used to turn a kWh SoC into a percent stop-SoC.
     pub battery_capacity_kwh: f64,
 }
@@ -33,15 +36,17 @@ pub struct SlotWindow {
 
 /// Turn a kW setpoint into the inverter's integer `powerrate` percent against `max_power_kw`
 /// (battery max charge/discharge power = 100%), quantized to `step_pct`. A **nonzero** setpoint
-/// floors at 1% (an active slot must request ≥1%, matching loxone's `max(1, …)`); 0 kW maps to 0.
-pub fn powerrate_pct(kw: f64, max_power_kw: f64, step_pct: f64) -> u32 {
+/// floors at `min_pct` — the inverter rejects (NAKs, no ack) a powerrate below its minimum, so
+/// `loxone_smart_home` floors the adaptive rate at `min_charge_power_rate` (25%) "so charging never
+/// trickles below the gentle baseline". 0 kW maps to 0 (slot off).
+pub fn powerrate_pct(kw: f64, max_power_kw: f64, step_pct: f64, min_pct: f64) -> u32 {
     if max_power_kw <= 0.0 || kw <= 0.0 {
         return 0;
     }
     let raw = (kw / max_power_kw * 100.0).clamp(0.0, 100.0);
     let step = step_pct.max(1.0);
     let pct = ((raw / step).round() * step).clamp(0.0, 100.0).round() as u32;
-    pct.max(1)
+    pct.max(min_pct.clamp(1.0, 100.0).round() as u32)
 }
 
 /// kWh → integer stop-SoC percent (clamped 0..100).
@@ -114,7 +119,14 @@ pub fn translate(
 
     let min_pct = soc_pct(b.min_soc_kwh, cfg.battery_capacity_kwh);
     let max_pct = soc_pct(b.max_soc_kwh, cfg.battery_capacity_kwh);
-    let pct = |kw: f64| powerrate_pct(kw, cfg.battery_power_max_kw, cfg.powerrate_step_pct);
+    let pct = |kw: f64| {
+        powerrate_pct(
+            kw,
+            cfg.battery_power_max_kw,
+            cfg.powerrate_step_pct,
+            cfg.min_powerrate_pct,
+        )
+    };
 
     let mut a = vec![action(
         base,
@@ -277,6 +289,7 @@ mod tests {
             command_base: "energy/solar/command".into(),
             battery_power_max_kw: 9.8,
             powerrate_step_pct: 1.0,
+            min_powerrate_pct: 25.0,
             battery_capacity_kwh: 10.0,
         }
     }
@@ -311,12 +324,16 @@ mod tests {
 
     #[test]
     fn powerrate_quantizes_and_clamps() {
-        assert_eq!(powerrate_pct(9.8, 9.8, 1.0), 100); // full
-        assert_eq!(powerrate_pct(3.0, 9.8, 1.0), 31); // 30.6 → 31
-        assert_eq!(powerrate_pct(99.0, 9.8, 1.0), 100); // clamp
-        assert_eq!(powerrate_pct(0.0, 9.8, 1.0), 0); // zero stays zero
-        assert_eq!(powerrate_pct(0.04, 9.8, 1.0), 1); // nonzero floors at 1% (loxone max(1,…))
-        assert_eq!(powerrate_pct(2.45, 9.8, 5.0), 25); // 25% on step 5
+        assert_eq!(powerrate_pct(9.8, 9.8, 1.0, 1.0), 100); // full
+        assert_eq!(powerrate_pct(3.0, 9.8, 1.0, 1.0), 31); // 30.6 → 31
+        assert_eq!(powerrate_pct(99.0, 9.8, 1.0, 1.0), 100); // clamp
+        assert_eq!(powerrate_pct(0.0, 9.8, 1.0, 1.0), 0); // zero stays zero (no floor)
+        assert_eq!(powerrate_pct(0.04, 9.8, 1.0, 1.0), 1); // nonzero floors at min (here 1%)
+        assert_eq!(powerrate_pct(2.45, 9.8, 5.0, 1.0), 25); // 25% on step 5
+                                                            // A tiny setpoint floors at the inverter minimum (loxone's min_charge_power_rate, 25%) so the
+                                                            // inverter doesn't NAK an out-of-range rate; 0 kW still maps to 0 (slot off, no floor).
+        assert_eq!(powerrate_pct(0.43, 9.8, 1.0, 25.0), 25);
+        assert_eq!(powerrate_pct(0.0, 9.8, 1.0, 25.0), 0);
     }
 
     #[test]
@@ -386,8 +403,8 @@ mod tests {
         ); // min 2/10
         assert_eq!(
             find(&a, "/gridfirst/set/powerrate").message,
-            r#"{"value":20}"#
-        ); // 2/9.8 = 20.4 → 20
+            r#"{"value":25}"#
+        ); // 2/9.8 = 20.4 → floored to the 25% minimum (loxone's discharge/charge powerRate floor)
            // Exclusivity: the opposite (battery-first) slot is explicitly disabled.
         assert_eq!(
             find(&a, "/batteryfirst/set/timeslot").message,
@@ -475,15 +492,16 @@ mod tests {
 
     #[test]
     fn powerrate_step_edge_cases() {
+        // (min_pct=1 here isolates the step/quantization behaviour from the minimum floor.)
         // On a step boundary after rounding (2.65/5.3 = 50%, step 5).
-        assert_eq!(powerrate_pct(2.65, 5.3, 5.0), 50);
+        assert_eq!(powerrate_pct(2.65, 5.3, 5.0, 1.0), 50);
         // Low end with a larger step.
-        assert_eq!(powerrate_pct(0.265, 5.3, 5.0), 5);
+        assert_eq!(powerrate_pct(0.265, 5.3, 5.0, 1.0), 5);
         // step=0 is treated as 1 (the .max(1.0) guard).
-        assert_eq!(powerrate_pct(2.65, 5.3, 0.0), 50);
+        assert_eq!(powerrate_pct(2.65, 5.3, 0.0, 1.0), 50);
         // Fractional step.
-        assert_eq!(powerrate_pct(1.325, 5.3, 0.5), 25);
+        assert_eq!(powerrate_pct(1.325, 5.3, 0.5, 1.0), 25);
         // kw exceeding the rating clamps to 100.
-        assert_eq!(powerrate_pct(10.0, 5.3, 1.0), 100);
+        assert_eq!(powerrate_pct(10.0, 5.3, 1.0, 1.0), 100);
     }
 }

--- a/controllers/publisher/src/build.rs
+++ b/controllers/publisher/src/build.rs
@@ -29,14 +29,14 @@ pub fn commands(
     seq: u64,
     now: DateTime<Utc>,
 ) -> Vec<(String, ControlCommand)> {
-    let fs = &api.data.plan.first_step;
+    let fs = &api.data.first_step;
     let valid_until = now + Duration::seconds(cfg.deadman_seconds.max(0));
-    let plan_id = api.data.computed_at.to_rfc3339();
+    let plan_id = api.computed_at.to_rfc3339();
 
     let envelope = |controller_id: &str, payload: Payload| ControlCommand {
         schema_version: SCHEMA_VERSION.to_string(),
         controller_id: controller_id.to_string(),
-        issued_at: api.data.computed_at,
+        issued_at: api.computed_at,
         block_start: fs.hour_start,
         valid_until,
         plan_id: plan_id.clone(),
@@ -47,7 +47,7 @@ pub fn commands(
     let mut out = Vec::new();
 
     if let Some(b) = &cfg.battery {
-        let soc_kwh = api.data.plan.timeline.first().map(|t| t.soc_kwh);
+        let soc_kwh = api.data.timeline.first().map(|t| t.soc_kwh);
         let payload = Payload::Battery(BatteryPayload {
             slot: parse_slot(&fs.mode.slot),
             export_enabled: fs.mode.export_enabled,
@@ -85,7 +85,6 @@ pub fn commands(
         // place rather than forcing it to 0 kW. The first block's planned power is the setpoint.
         let mut channels: Vec<LoadChannel> = api
             .data
-            .plan
             .ev
             .iter()
             .filter(|c| c.controllable_now && !c.charge_kw.is_empty())
@@ -125,31 +124,28 @@ mod tests {
             "computed_at": "2026-06-23T12:00:00Z",
             "age_seconds": 4,
             "data": {
-                "computed_at": "2026-06-23T12:00:00Z",
-                "plan": {
-                    "total_cost_eur": 1.23,
-                    "first_step": {
-                        "hour_start": "2026-06-23T12:00:00Z",
-                        "heat_kw": { "livingroom": 2.4, "office": 0.0 },
-                        "cool_kw": {},
-                        "battery_charge_kw": 3.0,
-                        "battery_discharge_kw": 0.0,
-                        "grid_import_kw": 3.0,
-                        "grid_export_kw": 0.0,
-                        "mode": {
-                            "slot": "charge_from_grid",
-                            "export_enabled": false,
-                            "inverter_on": true,
-                            "charge_kw": 3.0,
-                            "discharge_kw": 0.0
-                        }
-                    },
-                    "timeline": [ { "soc_kwh": 6.1, "slot": "charge_from_grid" } ],
-                    "ev": [
-                        { "name": "garage", "controllable_now": true, "charge_kw": [3.6, 0.0], "target_pct": 80.0 },
-                        { "name": "street", "controllable_now": false, "charge_kw": [0.0], "target_pct": 90.0 }
-                    ]
-                }
+                "total_cost_eur": 1.23,
+                "first_step": {
+                    "hour_start": "2026-06-23T12:00:00Z",
+                    "heat_kw": { "livingroom": 2.4, "office": 0.0 },
+                    "cool_kw": {},
+                    "battery_charge_kw": 3.0,
+                    "battery_discharge_kw": 0.0,
+                    "grid_import_kw": 3.0,
+                    "grid_export_kw": 0.0,
+                    "mode": {
+                        "slot": "charge_from_grid",
+                        "export_enabled": false,
+                        "inverter_on": true,
+                        "charge_kw": 3.0,
+                        "discharge_kw": 0.0
+                    }
+                },
+                "timeline": [ { "soc_kwh": 6.1, "slot": "charge_from_grid" } ],
+                "ev": [
+                    { "name": "garage", "controllable_now": true, "charge_kw": [3.6, 0.0], "target_pct": 80.0 },
+                    { "name": "street", "controllable_now": false, "charge_kw": [0.0], "target_pct": 90.0 }
+                ]
             }
         }"#;
         serde_json::from_str(json).unwrap()

--- a/controllers/publisher/src/plan.rs
+++ b/controllers/publisher/src/plan.rs
@@ -6,17 +6,12 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use std::collections::HashMap;
 
-/// The `{ computed_at, age_seconds, data }` envelope.
+/// The `{ computed_at, age_seconds, data }` envelope every API endpoint returns. `computed_at` is the
+/// envelope timestamp (sibling of `data`); `data` is the plan report itself.
 #[derive(Debug, Clone, Deserialize)]
 pub struct LatestResponse {
-    pub data: TimestampedPlan,
-}
-
-/// `data`: the published plan plus when it was computed.
-#[derive(Debug, Clone, Deserialize)]
-pub struct TimestampedPlan {
     pub computed_at: DateTime<Utc>,
-    pub plan: PlanReport,
+    pub data: PlanReport,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/deploy/controller.Dockerfile
+++ b/deploy/controller.Dockerfile
@@ -1,0 +1,13 @@
+# Minimal image for an MPC hardware controller (a static musl binary + its JSON5 config).
+#
+# The config is **bind-mounted** at runtime (see deploy/run-growatt.sh / run-publisher.sh), so the
+# `armed` flag and host/topic edits take effect on restart with no image rebuild — and an armed config
+# never gets baked into an image. Build it with the static binary copied next to this file:
+#   docker build -f controller.Dockerfile --build-arg BIN=mpc-controller-growatt -t mpc-growatt .
+#   docker build -f controller.Dockerfile --build-arg BIN=mpc-plan-publisher    -t mpc-publisher .
+FROM alpine:3.20
+WORKDIR /app
+ARG BIN
+COPY ${BIN} /app/controller
+# The controllers read their config from argv[1]; run scripts bind-mount the host file here.
+ENTRYPOINT ["/app/controller", "/app/config.json5"]

--- a/deploy/healthcheck.sh
+++ b/deploy/healthcheck.sh
@@ -3,17 +3,17 @@
 # Prints "OK | <summary>" or "ANOMALY:<flags> | <summary>". Used by the monitoring watchdog.
 D="${DOCKER:-/usr/local/bin/docker}"
 LAN="${MPC_LAN_URL:-http://127.0.0.1:3000}"   # override per host (the brain's published API URL)
-N=$($D ps --filter name=mpc-brain --filter name=mpc-publisher --filter name=mpc-growatt --format '{{.Names}}' | wc -l | tr -d ' ')
+N=$("$D" ps --filter name=mpc-brain --filter name=mpc-publisher --filter name=mpc-growatt --format '{{.Names}}' | wc -l | tr -d ' ')
 RZ=$(curl -s -m8 -o /dev/null -w '%{http_code}' "$LAN/readyz")
 PLAN=$(curl -s -m8 "$LAN/api/plan/latest")
 DEC=$(printf '%s' "$PLAN" | python3 "$(dirname "$0")/parse_plan.py")
 PH=$(echo "$DEC" | cut -d'|' -f1); SLOT=$(echo "$DEC" | cut -d'|' -f2)
 SOC=$(echo "$DEC" | cut -d'|' -f3); CHG=$(echo "$DEC" | cut -d'|' -f4); BAD=$(echo "$DEC" | cut -d'|' -f5)
-GERR=$($D logs --since 11m mpc-growatt 2>&1 | grep -ciE 'GAVE UP|panic')
-PFAIL=$($D logs --since 11m mpc-publisher 2>&1 | grep -ciE 'poll.*failed|panic')
-ACKF=$($D logs --since 11m mpc-growatt 2>&1 | grep -c '"success":false')
+GERR=$("$D" logs --since 11m mpc-growatt 2>&1 | grep -ciE 'GAVE UP|panic')
+PFAIL=$("$D" logs --since 11m mpc-publisher 2>&1 | grep -ciE 'poll.*failed|panic')
+ACKF=$("$D" logs --since 11m mpc-growatt 2>&1 | grep -c '"success":false')
 # Live inverter telemetry: confirm the plan is actually being executed (e.g. discharging when told to).
-TEL=$(timeout 8 $D exec mosquitto mosquitto_sub -t energy/solar -C 1 2>/dev/null | python3 -c "import sys,json
+TEL=$(timeout 8 "$D" exec mosquitto mosquitto_sub -t energy/solar -C 1 2>/dev/null | python3 -c "import sys,json
 try:
  d=json.load(sys.stdin); print('|'.join([str(d.get('DischargePower',0)), str(d.get('ChargePower',0)), str(d.get('ACPowerToGrid',0))]))
 except Exception: print('?|?|?')")

--- a/deploy/healthcheck.sh
+++ b/deploy/healthcheck.sh
@@ -12,14 +12,26 @@ SOC=$(echo "$DEC" | cut -d'|' -f3); CHG=$(echo "$DEC" | cut -d'|' -f4); BAD=$(ec
 GERR=$($D logs --since 11m mpc-growatt 2>&1 | grep -ciE 'GAVE UP|panic')
 PFAIL=$($D logs --since 11m mpc-publisher 2>&1 | grep -ciE 'poll.*failed|panic')
 ACKF=$($D logs --since 11m mpc-growatt 2>&1 | grep -c '"success":false')
-# `topoff` (charge_from_grid at ~full SoC) is informational only: the stop-SoC caps the actual charge,
-# so the inverter won't overcharge — not an anomaly. The real trips are operational failures.
-SUMMARY="containers=$N readyz=$RZ slot=$SLOT soc=$SOC chg=$CHG ph=$PH gerr=$GERR pfail=$PFAIL ackfail=$ACKF topoff=$BAD"
+# Live inverter telemetry: confirm the plan is actually being executed (e.g. discharging when told to).
+TEL=$(timeout 8 $D exec mosquitto mosquitto_sub -t energy/solar -C 1 2>/dev/null | python3 -c "import sys,json
+try:
+ d=json.load(sys.stdin); print('|'.join([str(d.get('DischargePower',0)), str(d.get('ChargePower',0)), str(d.get('ACPowerToGrid',0))]))
+except Exception: print('?|?|?')")
+DIS=$(echo "$TEL" | cut -d'|' -f1); CHGW=$(echo "$TEL" | cut -d'|' -f2); EXP=$(echo "$TEL" | cut -d'|' -f3)
+# Discharge stall: plan says discharge_to_grid with clear headroom (soc well above the floor), but the
+# inverter isn't discharging — the command didn't take effect. (Numeric soc>2.8 guards the ~2 kWh floor;
+# the leading-digit check tolerates a non-numeric soc.)
+STALL=0
+case "$SLOT" in discharge_to_grid)
+  case "$DIS" in 0|0.0) case "$SOC" in 2.[0-7]*|2|1.*|0.*) ;; *) STALL=1;; esac;; esac;; esac
+# `topoff` (charge_from_grid at ~full SoC) is informational: the stop-SoC caps the charge, no overcharge.
+SUMMARY="containers=$N readyz=$RZ slot=$SLOT soc=$SOC chg=$CHG dis_w=$DIS exp_w=$EXP ph=$PH gerr=$GERR pfail=$PFAIL ackfail=$ACKF topoff=$BAD"
 A=""
 [ "$N" = "3" ] || A="$A containers_down"
 [ "$RZ" = "200" ] || A="$A readyz"
 [ "$PH" = "0" ] || A="$A placeholders"
 [ "$GERR" = "0" ] || A="$A growatt_giveup_or_panic"
-[ "$PFAIL" = "0" ] || A="$A publisher_failures"
+[ "$PFAIL" -lt 2 ] || A="$A publisher_failures"   # tolerate a single transient poll-miss (deadman has 120s headroom); trip on 2+
 [ "$ACKF" = "0" ] || A="$A inverter_ack_failure"
+[ "$STALL" = "0" ] || A="$A discharge_not_executing"
 if [ -n "$A" ]; then echo "ANOMALY:$A | $SUMMARY"; else echo "OK | $SUMMARY"; fi

--- a/deploy/healthcheck.sh
+++ b/deploy/healthcheck.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# One-shot health verdict for the armed MPC control stack (brain + publisher + growatt).
+# Prints "OK | <summary>" or "ANOMALY:<flags> | <summary>". Used by the monitoring watchdog.
+D="${DOCKER:-/usr/local/bin/docker}"
+LAN="${MPC_LAN_URL:-http://127.0.0.1:3000}"   # override per host (the brain's published API URL)
+N=$($D ps --filter name=mpc-brain --filter name=mpc-publisher --filter name=mpc-growatt --format '{{.Names}}' | wc -l | tr -d ' ')
+RZ=$(curl -s -m8 -o /dev/null -w '%{http_code}' "$LAN/readyz")
+PLAN=$(curl -s -m8 "$LAN/api/plan/latest")
+DEC=$(printf '%s' "$PLAN" | python3 "$(dirname "$0")/parse_plan.py")
+PH=$(echo "$DEC" | cut -d'|' -f1); SLOT=$(echo "$DEC" | cut -d'|' -f2)
+SOC=$(echo "$DEC" | cut -d'|' -f3); CHG=$(echo "$DEC" | cut -d'|' -f4); BAD=$(echo "$DEC" | cut -d'|' -f5)
+GERR=$($D logs --since 11m mpc-growatt 2>&1 | grep -ciE 'GAVE UP|panic')
+PFAIL=$($D logs --since 11m mpc-publisher 2>&1 | grep -ciE 'poll.*failed|panic')
+ACKF=$($D logs --since 11m mpc-growatt 2>&1 | grep -c '"success":false')
+# `topoff` (charge_from_grid at ~full SoC) is informational only: the stop-SoC caps the actual charge,
+# so the inverter won't overcharge — not an anomaly. The real trips are operational failures.
+SUMMARY="containers=$N readyz=$RZ slot=$SLOT soc=$SOC chg=$CHG ph=$PH gerr=$GERR pfail=$PFAIL ackfail=$ACKF topoff=$BAD"
+A=""
+[ "$N" = "3" ] || A="$A containers_down"
+[ "$RZ" = "200" ] || A="$A readyz"
+[ "$PH" = "0" ] || A="$A placeholders"
+[ "$GERR" = "0" ] || A="$A growatt_giveup_or_panic"
+[ "$PFAIL" = "0" ] || A="$A publisher_failures"
+[ "$ACKF" = "0" ] || A="$A inverter_ack_failure"
+if [ -n "$A" ]; then echo "ANOMALY:$A | $SUMMARY"; else echo "OK | $SUMMARY"; fi

--- a/deploy/parse_plan.py
+++ b/deploy/parse_plan.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Reads an /api/plan/latest envelope on stdin, prints "ph|slot|soc|chg|bad" for healthcheck.sh.
+import sys, json
+try:
+    d = json.load(sys.stdin).get('data', {})
+    m = d.get('first_step', {}).get('mode', {})
+    tl = d.get('timeline', [])
+    soc = tl[0].get('soc_kwh') if tl else None
+    ph = d.get('placeholder_inputs', [])
+    slot = m.get('slot')
+    chg = m.get('charge_kw')
+    bad = 1 if (soc is not None and soc > 9.0 and slot == 'charge_from_grid') else 0
+    print('|'.join([str(len(ph)), str(slot), str(soc), str(chg), str(bad)]))
+except Exception as e:
+    print('|'.join(['ERR', 'parse', str(e).replace('|', ' '), '0', '1']))

--- a/deploy/run-container.sh
+++ b/deploy/run-container.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
-# Run the read-only shadow brain container alongside the loxone stack (crash + reboot persistence).
+# Run the read-only MPC brain container alongside the loxone stack (crash + reboot persistence).
+# This is the read-only planner: it serves the dashboard/API and /api/plan/latest, and never
+# actuates. The actuation path is the separate controller containers (see deploy/run-growatt.sh).
 # Copy this next to the built binary + config.json5 + model.json5 and run it from there.
 #
 # config.json5 / model.json5 are mounted read-only from this dir, so edits take effect on restart
@@ -30,9 +32,9 @@ for v in $(env | sed -nE 's/^(MPC_PG_[A-Z0-9_]+)=.*/\1/p'); do
   PG_ENV="$PG_ENV -e $v"
 done
 mkdir -p "$DIR/data"
-$DOCKER rm -f mpc-shadow 2>/dev/null
+$DOCKER rm -f mpc-brain 2>/dev/null
 # shellcheck disable=SC2086
-$DOCKER run -d --name mpc-shadow --restart unless-stopped \
+$DOCKER run -d --name mpc-brain --restart unless-stopped \
   --network caddy_net \
   -e INFLUX_HOST=http://influxdb:8086 -e MPC_BIND=0.0.0.0 -e INFLUXDB_TOKEN="$TOKEN" \
   -e MPC_FORECAST_STORE=/app/data/forecast_snapshots.json \
@@ -41,4 +43,4 @@ $DOCKER run -d --name mpc-shadow --restart unless-stopped \
   -v "$DIR/model.json5:/app/model.json5:ro" \
   -v "$DIR/data:/app/data" \
   -p "$MPC_PORT:3000" \
-  mpc-shadow
+  mpc-brain

--- a/deploy/run-growatt.sh
+++ b/deploy/run-growatt.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Run the Growatt controller — the SOUTH bridge to the real inverter. It subscribes to the publisher's
+# `mpc/control/growatt` commands and translates them into the real `energy/solar/command/...` Growatt
+# MQTT commands.
+#
+# **It actuates the inverter ONLY when BOTH are true:** the config has `armed: true`, AND this script
+# is run with `MPC_CONTROLLER_ARM=i-understand-this-actuates` in the environment. Otherwise it is
+# dry-run (logs the would-send messages, touches nothing) — so the default below is dry-run, and
+# arming is a deliberate, explicit act:
+#
+#   # dry-run (pre-flight: watch `docker logs -f mpc-growatt` for the would-send commands)
+#   sh ./run-growatt.sh
+#   # armed (only once loxone's Growatt control is OFF — never two controllers on one inverter)
+#   MPC_CONTROLLER_ARM=i-understand-this-actuates sh ./run-growatt.sh
+#
+# Runs on caddy_net so it reaches the broker (mosquitto:1883). A `valid_until` deadman hands control
+# back (failsafe) if the plan ever goes silent. The config is bind-mounted (edit + restart, no rebuild).
+#
+# Override for your host:
+#   DOCKER   docker binary           (default: docker)
+#   DIR      dir holding growatt.json5 (default: this script's dir)
+DOCKER="${DOCKER:-docker}"
+DIR="${DIR:-$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)}"
+ARM_ENV=""
+if [ -n "$MPC_CONTROLLER_ARM" ]; then
+  ARM_ENV="-e MPC_CONTROLLER_ARM=$MPC_CONTROLLER_ARM"
+  echo "run-growatt.sh: ARM token present — controller will actuate IF its config has armed:true."
+else
+  echo "run-growatt.sh: no ARM token — dry-run (logs only, no actuation)."
+fi
+$DOCKER rm -f mpc-growatt 2>/dev/null
+# shellcheck disable=SC2086
+$DOCKER run -d --name mpc-growatt --restart unless-stopped \
+  --network caddy_net \
+  $ARM_ENV \
+  -v "$DIR/growatt.json5:/app/config.json5:ro" \
+  mpc-growatt

--- a/deploy/run-publisher.sh
+++ b/deploy/run-publisher.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Run the plan publisher — the NORTH bridge. It polls the read-only brain's /api/plan/latest and
+# republishes per-block commands to the inert `mpc/control/...` MQTT namespace. This touches no
+# hardware on its own (the device controllers translate mpc/control → real device commands), but it
+# only emits when its config has `armed: true`.
+#
+# Runs on caddy_net so it reaches the brain (mpc-brain:3000) and the broker (mosquitto:1883) by name.
+# The config is bind-mounted, so flip `armed` / edit topics with a host edit + restart (no rebuild).
+#
+# Override for your host:
+#   DOCKER   docker binary           (default: docker)
+#   DIR      dir holding publisher.json5 (default: this script's dir)
+DOCKER="${DOCKER:-docker}"
+DIR="${DIR:-$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)}"
+$DOCKER rm -f mpc-publisher 2>/dev/null
+$DOCKER run -d --name mpc-publisher --restart unless-stopped \
+  --network caddy_net \
+  -v "$DIR/publisher.json5:/app/config.json5:ro" \
+  mpc-publisher

--- a/src/app.rs
+++ b/src/app.rs
@@ -353,6 +353,9 @@ pub struct TimelineBlock {
     pub export_price: f64,
     /// Forecast PV generation (kW) — the calibrated Solcast curve, or the clear-sky fallback.
     pub pv_kw: f64,
+    /// Forecast base house load (kW) — the consumption model's prediction the optimizer planned
+    /// around (the predicted `INVPowerToLocalLoad`, charted vs the measured `house_kw`).
+    pub load_kw: f64,
     /// Battery state of charge (kWh) at the end of the block.
     pub soc_kwh: f64,
     pub charge_kw: f64,
@@ -800,6 +803,7 @@ pub async fn current_plan(
                 import_price: ctx.import_price.get(b).copied().unwrap_or(0.0),
                 export_price: ctx.export_price.get(b).copied().unwrap_or(0.0),
                 pv_kw: pv_series.get(b).copied().unwrap_or(0.0),
+                load_kw: at(&plan.load_kw),
                 soc_kwh: soc,
                 charge_kw: charge,
                 discharge_kw: discharge,

--- a/src/app.rs
+++ b/src/app.rs
@@ -164,10 +164,11 @@ fn tariff_prices(
         .unzip()
 }
 
-/// The recommended Growatt configuration for one 15-min block (shadow): the inverter **slot mode**
-/// plus the two **independent, price-gated toggles** — export enable/disable and the inverter
-/// on/off master switch — mirroring how the live controller is actually set up. It is a read-off of
-/// the recommended intent, not a literal echo of the controller's register, and nothing is actuated.
+/// The recommended Growatt configuration for one 15-min block: the inverter **slot mode** plus the
+/// two **independent, price-gated toggles** — export enable/disable and the inverter on/off master
+/// switch — mirroring how the live controller is actually set up. It is a read-off of the recommended
+/// intent, not a literal echo of the controller's register; the brain itself never actuates — the
+/// **armed** Growatt controller applies it downstream (heating/EV stay shadow).
 #[derive(Debug, Clone, Serialize)]
 pub struct ModeStep {
     /// Battery action in `loxone_smart_home`'s vocabulary: `regular` / `charge_from_grid` /
@@ -300,8 +301,8 @@ pub struct PlanReport {
     /// PV-array and battery hardware specs come from `config.json5`; a "PV (Solcast unavailable…)"
     /// entry here means the clear-sky model over those arrays stood in for the Solcast forecast.
     pub placeholder_inputs: Vec<String>,
-    /// The controls the optimizer chose for the coming block — what a controller *would* apply
-    /// (shadow only; nothing is actuated).
+    /// The controls the optimizer chose for the coming block — the battery plan drives the **armed**
+    /// Growatt controller; the heating decisions stay shadow (advisory, not actuated).
     pub first_step: FirstStep,
     /// The full per-15-min-block plan as **timestamped rows** — prices, PV, SoC, battery, grid,
     /// heating and predicted temperature per controlled zone, plus the recommended Growatt mode.
@@ -372,7 +373,8 @@ pub struct TimelineBlock {
     pub hvac_heat_kw: HashMap<String, f64>,
     /// **Predicted** air temperature (°C) per controlled zone at the end of the block.
     pub temp_c: HashMap<String, f64>,
-    /// Recommended Growatt slot mode and the price-gated export / inverter levers (shadow only).
+    /// Recommended Growatt slot mode and the price-gated export / inverter levers — applied by the
+    /// armed Growatt controller for the live block.
     pub slot: String,
     pub export_enabled: bool,
     pub inverter_on: bool,
@@ -418,7 +420,8 @@ pub struct FirstStep {
     pub battery_discharge_kw: f64,
     pub grid_import_kw: f64,
     pub grid_export_kw: f64,
-    /// Recommended Growatt setup for the coming block (shadow only): slot mode + the two toggles.
+    /// Recommended Growatt setup for the coming block — slot mode + the two toggles, applied by the
+    /// armed Growatt controller.
     pub mode: ModeStep,
 }
 

--- a/src/dashboard/app.js
+++ b/src/dashboard/app.js
@@ -503,7 +503,7 @@ screens.model = {
   mount() {
     return `
     <div class="grid cols-2">
-      <section class="card"><div class="card-head"><div class="card-title"><span class="ico">🎯</span> Forward prediction vs measured</div><div class="card-sub" id="vmeta"></div></div><div class="chart" id="m-valid"></div></section>
+      <section class="card"><div class="card-head"><div class="card-title"><span class="ico">🎯</span> Forward prediction vs measured — worst zone</div><div class="card-sub" id="vmeta"></div></div><div class="chart" id="m-valid"></div></section>
       <section class="card"><div class="card-head"><div class="card-title"><span class="ico">📐</span> Per-zone prediction error (RMSE)</div></div><div class="chart" id="m-rmse"></div></section>
     </div>
     <section class="card span-full" style="margin-top:18px">
@@ -516,8 +516,8 @@ screens.model = {
     const cal = store['/api/calibration/gains']?.data;
 
     if (val?.zones?.length) {
-      $('#vmeta').textContent = val.mean_rmse_k != null ? `mean RMSE ${fmt.n(val.mean_rmse_k, 2)} K · since ${fmt.hm(val.anchored_at)}` : '—';
       const worst = val.zones[0];
+      $('#vmeta').textContent = val.mean_rmse_k != null ? `worst: ${worst.zone.replace(/_/g, ' ')} · mean RMSE ${fmt.n(val.mean_rmse_k, 2)} K · ${val.zones.length} zones · since ${fmt.hm(val.anchored_at)}` : '—';
       if (worst?.points?.length) {
         chart('m-valid')?.setOption(Object.assign(baseOption(), {
           legend: { top: 0, textStyle: { color: css('--muted') } },
@@ -528,30 +528,36 @@ screens.model = {
           ],
         }), true);
       }
+      // ECharts category axis renders index 0 at the bottom, so reverse to put the worst zone on top.
+      const zrev = [...val.zones].reverse();
       chart('m-rmse')?.setOption({
-        textStyle: { color: css('--muted') }, grid: { left: 90, right: 20, top: 10, bottom: 24 },
-        tooltip: { trigger: 'axis', confine: true, axisPointer: { type: 'shadow' }, valueFormatter: (v) => typeof v === 'number' ? v.toFixed(2) : v },
+        textStyle: { color: css('--muted') }, grid: { left: 90, right: 30, top: 10, bottom: 24 },
+        tooltip: { trigger: 'axis', confine: true, axisPointer: { type: 'shadow' },
+          formatter: (ps) => { const z = zrev[ps[0].dataIndex]; if (!z) return ''; const b = z.mean_bias_k; return `${z.zone.replace(/_/g, ' ')}<br/>RMSE ${z.rmse_k.toFixed(2)} K · bias ${b >= 0 ? '+' : ''}${b.toFixed(2)} K · n=${z.n}`; } },
         xAxis: { type: 'value', axisLabel: { color: css('--muted') }, splitLine: { lineStyle: { color: css('--surface-2') } } },
-        yAxis: { type: 'category', data: val.zones.map((z) => z.zone.replace(/_/g, ' ')).reverse(), axisLabel: { color: css('--muted') } },
-        series: [{ type: 'bar', data: [...val.zones].reverse().map((z) => z.rmse_k), itemStyle: { color: css('--blue'), borderRadius: [0, 4, 4, 0] } }],
+        yAxis: { type: 'category', data: zrev.map((z) => z.zone.replace(/_/g, ' ')), axisLabel: { color: css('--muted') } },
+        series: [{ type: 'bar', data: zrev.map((z) => z.rmse_k), itemStyle: { color: css('--blue'), borderRadius: [0, 4, 4, 0] } }],
       }, true);
     } else {
       $('#vmeta').textContent = 'warming up — scoring needs ≥3 h of measured data after a snapshot';
     }
 
     if (cal) {
-      $('#gmeta').textContent = cal.live?.fitted_at ? `fitted ${fmt.hm(cal.live.fitted_at)} · ${cal.window_days}-day window · re-fits every ${cal.recalibrate_hours}h` : 'config baseline';
+      $('#gmeta').textContent = cal.live?.fitted_at ? `fitted ${fmt.hm(cal.live.fitted_at)} · ${cal.window_days}-day window · re-fits every ${cal.recalibrate_hours}h · no bar = not fitted / not configured` : 'config baseline';
       const live = cal.live?.gains_w || {}; const base = cal.config_baseline_w || {};
       const znames = [...new Set([...Object.keys(live), ...Object.keys(base)])].sort();
+      // `?? null` (not `|| 0`): an absent zone draws NO bar, so "not fitted" / "not configured" can't be
+      // misread as a real 0 W gain. Value labels keep the small live bars legible next to big baselines.
+      const lbl = { show: true, position: 'top', color: css('--muted'), fontSize: 9, formatter: (p) => p.value != null ? Math.round(p.value) : '' };
       chart('m-gains')?.setOption({
         textStyle: { color: css('--muted') }, grid: { left: 50, right: 20, top: 28, bottom: 60, containLabel: true },
-        tooltip: { trigger: 'axis', confine: true, axisPointer: { type: 'shadow' }, valueFormatter: (v) => typeof v === 'number' ? v.toFixed(2) : v },
+        tooltip: { trigger: 'axis', confine: true, axisPointer: { type: 'shadow' }, valueFormatter: (v) => v == null ? 'n/a' : v.toFixed(0) + ' W' },
         legend: { top: 0, textStyle: { color: css('--muted') } },
         xAxis: { type: 'category', data: znames.map((z) => z.replace(/_/g, ' ')), axisLabel: { color: css('--muted'), rotate: 35 } },
         yAxis: { type: 'value', name: 'W', axisLabel: { color: css('--muted') }, splitLine: { lineStyle: { color: css('--surface-2') } } },
         series: [
-          { name: 'live fit', type: 'bar', data: znames.map((z) => live[z] || 0), itemStyle: { color: css('--green'), borderRadius: [4, 4, 0, 0] } },
-          { name: 'config baseline', type: 'bar', data: znames.map((z) => base[z] || 0), itemStyle: { color: css('--faint'), borderRadius: [4, 4, 0, 0] } },
+          { name: 'live fit', type: 'bar', data: znames.map((z) => live[z] ?? null), label: lbl, itemStyle: { color: css('--green'), borderRadius: [4, 4, 0, 0] } },
+          { name: 'config baseline', type: 'bar', data: znames.map((z) => base[z] ?? null), label: lbl, itemStyle: { color: css('--faint'), borderRadius: [4, 4, 0, 0] } },
         ],
       }, true);
     }

--- a/src/dashboard/app.js
+++ b/src/dashboard/app.js
@@ -345,7 +345,7 @@ screens.home = {
     $('#day-legend').innerHTML = modeLegend();
     c?.setOption(Object.assign(baseOption(), {
       tooltip: planTooltip(tl),
-      color: [price, pv, pv, house, house, soc, soc], // legend swatches follow the lines (series order), not ECharts' default palette
+      color: [price, pv, house, soc], // ONE entry per UNIQUE series name (first-appearance order) — ECharts colours legend items by unique name, so duplicate hist/forecast entries here would shift the swatches off the lines
       legend: { show: true, data: ['PV', 'House', 'SoC', 'Price'], top: 0, textStyle: { color: css('--muted') }, icon: 'roundRect', itemWidth: 12, itemHeight: 8 },
       grid: { left: 50, right: 56, top: 30, bottom: 30, containLabel: true },
       yAxis: [yAxis('Kč/kWh', { position: 'right' }), yAxis('kW · kWh', { position: 'left' })],

--- a/src/dashboard/app.js
+++ b/src/dashboard/app.js
@@ -377,7 +377,7 @@ screens.energy = {
       <section class="card"><div class="card-head"><div class="card-title"><span class="ico">🔌</span> Grid &amp; curtailment</div></div><div class="chart" id="e-grid"></div></section>
     </div>
     <section class="card span-full" style="margin-top:18px">
-      <div class="card-head"><div class="card-title"><span class="ico">📋</span> Per-block plan</div><div class="card-sub">recommended Growatt mode — shadow only</div></div>
+      <div class="card-head"><div class="card-title"><span class="ico">📋</span> Per-block plan</div><div class="card-sub">Growatt mode applied per 15-min block</div></div>
       <div style="overflow-x:auto"><table class="tbl" id="e-table"></table></div>
     </section>`;
   },
@@ -427,8 +427,8 @@ screens.energy = {
 
     const i = nowBlock(tl);
     $('#e-table').innerHTML = `<thead><tr><th>Time</th><th class="num">Import</th><th class="num">Export</th><th class="num">PV</th><th class="num">SoC</th><th>Battery mode</th><th>Export on/off</th></tr></thead><tbody>`
-      + tl.filter((_, k) => k % 2 === 0).map((b, fi) => {
-        const m = modeOf(b.slot); const isNow = fi === Math.floor(i / 2); // the 30-min row containing "now"
+      + tl.map((b, fi) => {
+        const m = modeOf(b.slot); const isNow = fi === i; // the 15-min block containing "now"
         return `<tr class="${isNow ? 'now' : ''}"><td>${fmt.hm(b.t)}</td><td class="num">${fmt.n(b.import_price * rate, 2)}</td><td class="num">${fmt.n(b.export_price * rate, 2)}</td><td class="num">${fmt.n(b.pv_kw, 1)}</td><td class="num">${fmt.n(b.soc_kwh, 1)}</td><td><span class="badge" style="background:${m.color}22;color:${m.color}">${m.label}</span></td><td>${b.export_enabled ? '<span class="chip green" style="padding:1px 8px">on</span>' : '<span class="chip" style="padding:1px 8px">off</span>'}</td></tr>`;
       }).join('') + '</tbody>';
   },
@@ -564,7 +564,7 @@ screens.system = {
       <section class="card"><div class="card-head"><div class="card-title"><span class="ico">📡</span> Data feed health</div></div><div id="sys-feeds"></div></section>
     </div>
     <section class="card span-full" style="margin-top:18px">
-      <div class="card-head"><div class="card-title"><span class="ico">🧾</span> Decision now (raw)</div><div class="card-sub">what a controller would apply — shadow only, nothing actuated</div></div>
+      <div class="card-head"><div class="card-title"><span class="ico">🧾</span> Decision now (raw)</div><div class="card-sub">the raw per-controller decision (battery is armed; heating/EV shadow)</div></div>
       <div id="sys-decision"></div>
     </section>
     <section class="card span-full" style="margin-top:18px">

--- a/src/dashboard/app.js
+++ b/src/dashboard/app.js
@@ -340,13 +340,13 @@ screens.home = {
   },
   dayChart(tl, rate, store) {
     const c = chart('home-chart'); if (!c) return;
-    const pv = css('--yellow'), soc = css('--amber'), price = css('--blue');
+    const pv = css('--yellow'), soc = css('--amber'), price = css('--blue'), house = css('--red');
     const priceData = tl.map((b) => [b.t, b.import_price * rate]);
     $('#day-legend').innerHTML = modeLegend();
     c?.setOption(Object.assign(baseOption(), {
       tooltip: planTooltip(tl),
-      color: [price, pv, pv, soc, soc], // legend swatches follow the lines (series order), not ECharts' default palette
-      legend: { show: true, data: ['PV', 'SoC', 'Price'], top: 0, textStyle: { color: css('--muted') }, icon: 'roundRect', itemWidth: 12, itemHeight: 8 },
+      color: [price, pv, pv, house, house, soc, soc], // legend swatches follow the lines (series order), not ECharts' default palette
+      legend: { show: true, data: ['PV', 'House', 'SoC', 'Price'], top: 0, textStyle: { color: css('--muted') }, icon: 'roundRect', itemWidth: 12, itemHeight: 8 },
       grid: { left: 50, right: 56, top: 30, bottom: 30, containLabel: true },
       yAxis: [yAxis('Kč/kWh', { position: 'right' }), yAxis('kW · kWh', { position: 'left' })],
       series: [
@@ -354,6 +354,9 @@ screens.home = {
           markArea: { silent: true, data: modeBands(tl) }, markLine: nowMark() },
         { name: 'PV', type: 'line', yAxisIndex: 1, data: histData(store, 'pv_kw'), smooth: true, symbol: 'none', lineStyle: { color: pv, width: 2 }, areaStyle: { color: grad(pv) } },
         { name: 'PV', type: 'line', yAxisIndex: 1, data: tl.map((b) => [b.t, b.pv_kw]), smooth: true, symbol: 'none', lineStyle: { color: pv, width: 1.5, type: 'dashed' } },
+        // House consumption: measured (solid) vs the model's forecast (dashed) — same INVPowerToLocalLoad quantity.
+        { name: 'House', type: 'line', yAxisIndex: 1, data: histData(store, 'house_kw'), smooth: true, symbol: 'none', lineStyle: { color: house, width: 2 } },
+        { name: 'House', type: 'line', yAxisIndex: 1, data: tl.map((b) => [b.t, b.load_kw]), smooth: true, symbol: 'none', lineStyle: { color: house, width: 1.5, type: 'dashed' } },
         { name: 'SoC', type: 'line', yAxisIndex: 1, data: histData(store, 'soc_kwh'), smooth: true, symbol: 'none', lineStyle: { color: soc, width: 2 } },
         { name: 'SoC', type: 'line', yAxisIndex: 1, data: tl.map((b) => [b.t, b.soc_kwh]), smooth: true, symbol: 'none', lineStyle: { color: soc, width: 1.5, type: 'dashed' } },
       ],

--- a/src/live_inputs.rs
+++ b/src/live_inputs.rs
@@ -15,8 +15,8 @@ use crate::influxdb::PriceSample;
 use crate::source::SourceClients;
 
 const SOLAR_BUCKET: &str = "solar";
-/// Growatt battery state-of-charge lives in its own measurement, not `solar`.
-const GROWATT_MEASUREMENT: &str = "growatt_status";
+/// Max age (minutes) for the live battery SoC read; older ⇒ treated as missing (flagged placeholder).
+const SOC_MAX_AGE_MIN: i64 = 60;
 
 /// An RFC3339 instant Flux accepts unambiguously (`…Z`, not a `+00:00` offset).
 fn flux_time(t: DateTime<Utc>) -> String {
@@ -167,28 +167,19 @@ pub async fn train_consumption(
     Ok(Some(model))
 }
 
-/// The battery's current energy (kWh) from the live `battery_soc` (%) × capacity, or `None` if no
-/// telemetry (the caller keeps the default spec's initial SoC).
+/// The battery's current energy (kWh) from the live SoC (%) × capacity, or `None` if no telemetry
+/// (the caller keeps the default spec's initial SoC, flagged). Reads `SOC` through the **same**
+/// growatt locator as the dashboard (`solar`/`solar`/`SOC` by default) so the plan and `/api/live`
+/// can never disagree — not a hardcoded field/measurement.
 pub async fn battery_soc_kwh(db: &SourceClients, max_soc_kwh: f64) -> Result<Option<f64>> {
-    let soc = db
-        .read_series(
-            SOLAR_BUCKET,
-            GROWATT_MEASUREMENT,
-            "battery_soc",
-            &[],
-            "-2h",
-            "now()",
-            "1h",
-        )
+    Ok(db
+        .growatt_latest("SOC", SOC_MAX_AGE_MIN)
         .await
-        .unwrap_or_default();
-    Ok(soc
-        .last()
         // Require a finite, in-range percentage. An out-of-range value (e.g. 150 %) is corrupt
         // telemetry → report `None`, a flagged placeholder, so the bad data surfaces instead of
         // seeding a quietly-wrong SoC (matches `live.rs`'s SoC guard).
-        .filter(|s| s.value.is_finite() && (0.0..=100.0).contains(&s.value))
-        .map(|s| s.value / 100.0 * max_soc_kwh))
+        .filter(|pct| pct.is_finite() && (0.0..=100.0).contains(pct))
+        .map(|pct| pct / 100.0 * max_soc_kwh))
 }
 
 #[cfg(test)]

--- a/src/optimize/unified.rs
+++ b/src/optimize/unified.rs
@@ -76,6 +76,10 @@ pub struct UnifiedPlan {
     /// PV curtailed (kW) per block — solar neither used, stored, nor exported.
     pub curtail_kw: Vec<f64>,
     pub soc_kwh: Vec<f64>,
+    /// Forecast base house load (kW) per block — the consumption the optimizer planned around
+    /// (`INVPowerToLocalLoad`, the same quantity `/api/live`'s `house_kw` and the consumption model
+    /// use). Echoed from the input so the plan can be charted against the measured draw.
+    pub load_kw: Vec<f64>,
     /// Underfloor-heating power (kW) per heated zone, per step.
     pub heat_kw: HashMap<String, Vec<f64>>,
     /// HVAC cooling power (kW) per HVAC zone, per step.
@@ -703,6 +707,7 @@ pub fn optimize_unified(
         grid_export_kw: agg(&solar_to_grid, &batt_to_grid),
         curtail_kw: values(&curtail),
         soc_kwh: soc_after.iter().map(|e| e.eval_with(&solution)).collect(),
+        load_kw: inputs.load_kw.clone(),
         heat_kw,
         cool_kw,
         hvac_heat_kw,

--- a/src/web.rs
+++ b/src/web.rs
@@ -434,6 +434,7 @@ async fn get_history(
         let cap = s.config.battery.capacity_kwh.max(0.1);
         anyhow::Ok(json!({
             "pv_kw": measured_series(&s.db, "InputPower", &start, 0.001).await,
+            "house_kw": measured_series(&s.db, "INVPowerToLocalLoad", &start, 0.001).await,
             "soc_kwh": measured_series(&s.db, "SOC", &start, cap / 100.0).await,
         }))
     })


### PR DESCRIPTION
Codifies tonight's live cutover (loxone's Growatt control off → our MPC armed and actuating).

## Deploy scaffolding
- `deploy/run-container.sh`: the read-only planner container is now **`mpc-brain`** (was `mpc-shadow`) — it never actuates.
- `deploy/controller.Dockerfile` + `deploy/run-publisher.sh` + `deploy/run-growatt.sh`: deploy path for the `mpc-publisher` (north relay) and `mpc-growatt` (south actuator) containers. Growatt is **dry-run by default**; actuating needs both `armed: true` AND `MPC_CONTROLLER_ARM` in the env.

## Two bugs the live pre-flight caught (both blocked a correct cutover)
1. **Publisher couldn't parse `/api/plan/latest`** — its model expected `data.computed_at` + a phantom `data.plan` wrapper, but the envelope is `{ computed_at, age_seconds, data: <PlanReport> }`. The unit test encoded the same wrong shape, so it passed. Model + test corrected.
2. **Plan read battery SoC from the wrong measurement/field** (`growatt_status`/`battery_soc`, neither exists) — the real SoC is `solar`/`solar`/`SOC` (what `/api/live` reads). The plan always fell back to a default SoC and, with the battery full, wanted to grid-charge it. `battery_soc_kwh` now routes through the same `growatt_latest("SOC")` locator as the dashboard.

## Verified live
Brain plan reads 9.9 kWh (99%), decides `battery_hold` + export; all 6 commands reached the inverter and ACKed; deadman (120s `valid_until` → revert-to-regular) active; all containers `restart=unless-stopped`.