### PR TITLE
Scheduled loads: auto-fitted appliance heat fluxes (heat-pump sink / fireplace)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -69,10 +69,13 @@ it in the envelope above.
 - **`GET /api/thermal/backtest?mode=passive|active&window_hours=&warmup_hours=&start=&stop=`** — thermal model accuracy per zone (RMSE / bias / max error).
   - `passive` (default): free-response drift (summer). `window_hours` default 24, `warmup_hours` default 48.
   - `active`: driven by recorded heating relays; **fits** internal gains and returns `{before, after, gains_w}` (before/after = per-zone scores without/with the fitted gains). `start`/`stop` are Flux ranges (default `-{warmup+window}h` .. `now()`).
-- **`GET /api/calibration/gains`** — the live internal-gain self-correction:
+- **`GET /api/calibration/gains`** — the live internal-gain self-correction, plus each scheduled
+  load's magnitude (`source` is `"configured"` when `power_w` is set, else `"fitted"`):
 
 ```json
-{ "live": { "fitted_at": "…", "window_days": 7, "gains_w": {"livingroom": 83, …} },
+{ "live": { "fitted_at": "…", "window_days": 7, "gains_w": {"livingroom": 83, …},
+            "scheduled": [{"label": "water heat-pump", "zone": "technical_room",
+                           "magnitude_w": 1600, "source": "configured"}] },
   "config_baseline_w": {"livingroom": 351, …},
   "recalibrate_hours": 24, "window_days": 7 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,6 +266,50 @@ pv: {
 }
 ```
 
+### `scheduled_loads` (auto-fitted appliances)
+
+Optional. A **scheduled load** is a known appliance that injects or removes heat at a room's **air
+node** on a daily/seasonal schedule the physics model has no source for — e.g. a domestic-hot-water
+heat pump that draws heat *out* of its room while it runs, or a wood stove lit on a routine. You
+declare the **direction** and the **schedule**; the magnitude (W) is either **set** (`power_w`, when
+you know the draw) or **learnt from measured data** (omit `power_w` — the same trajectory fit that
+learns the per-zone internal gains). The model applies `magnitude × profile` as a flux in both the
+optimizer prediction and the backtest/fit drive.
+
+```json5
+scheduled_loads: [
+  {
+    zone: "technical_room",     // must be a zone in model.json5
+    label: "water heat-pump",   // optional; for logs/reports
+    kind: "sink",               // "sink" removes heat (cools the room) | "source" adds heat
+    power_w: 800,               // optional: set to fix the draw (W); omit to auto-fit from data
+    windows: [                  // local civil-time windows the load is active
+      { months: [5, 6, 7, 8, 9],          start: "10:00", end: "20:00" }, // summer: daytime
+      { months: [10, 11, 12, 1, 2, 3, 4], start: "01:00", end: "05:00" }, // winter: overnight
+    ],
+  },
+]
+```
+
+| Field | Unit | Notes |
+|---|---|---|
+| `zone` | — | zone whose **air node** the flux lands at; must exist in `model.json5` |
+| `label` | — | optional display name (logs, the active-backtest report) |
+| `kind` | — | `"sink"` (−, cools) or `"source"` (+, heats) — fixes the sign of the magnitude |
+| `power_w` | W | optional; **set** (> 0) to fix the draw, the model uses it as-is and the calibration won't touch it; **omit** to auto-fit |
+| `windows[].months` | 1–12 | optional; empty ⇒ every month |
+| `windows[].start` / `end` | `"HH:MM"` | local civil time; `start` inclusive, `end` exclusive; `end ≤ start` wraps past midnight |
+
+**Set `power_w`** when you know the appliance's draw (e.g. a nameplate-rated heat pump): the model
+applies it directly and the live re-fit leaves it alone. **Omit `power_w`** to have the calibration
+fit it (W, ≥ 0), so the example heat pump can need only its schedule and `kind`. The fit attributes
+the windowed effect to the load rather than smearing it into the always-on internal gain (a flat gain
+and a time-localized load are collinear against a single mean, but separate against the per-hour
+trajectory). A fitted load whose window doesn't overlap the fit window, or that barely moves any zone,
+is dropped (fitted to 0) and logged; a fixed load always applies. Each load's magnitude in use (and
+whether it's `configured` or `fitted`) is surfaced under `/api/calibration/gains` → `live.scheduled`.
+The schedule is **local** time — set `site.utc_offset_hours` correctly.
+
 ### Loop knobs (all optional, with defaults)
 
 | Key | Default | Meaning |

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,7 +32,7 @@ use crate::solar_forecast::pv_forecast_kw;
 use crate::source::SourceClients;
 use crate::state_space::StateSpace;
 use crate::tools::{c_to_k, k_to_c};
-use crate::validate::{self, BacktestConfig};
+use crate::validate::{self, BacktestConfig, GainFit};
 
 /// Planning horizon in hours (the span the weather/PV/consumption feeds are read over).
 const HORIZON_HOURS: usize = 24;
@@ -391,6 +391,22 @@ pub struct GainsSnapshot {
     pub window_days: i64,
     /// The fitted per-zone internal gains (W) now in use by the plan.
     pub gains_w: HashMap<String, f64>,
+    /// Per scheduled-load magnitude (W) now in use, aligned to `config.scheduled_loads` — each tagged
+    /// with whether it was `configured` (`power_w` set) or `fitted` (learnt from data).
+    pub scheduled: Vec<ScheduledFit>,
+}
+
+/// One scheduled load's magnitude as the plan currently sees it, for `/api/calibration/gains`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScheduledFit {
+    /// The load's label, or its zone when the label is empty.
+    pub label: String,
+    /// The zone whose air node the load acts on.
+    pub zone: String,
+    /// The magnitude in use (W, ≥ 0); the sign comes from the load's `kind`.
+    pub magnitude_w: f64,
+    /// `"configured"` if `power_w` was set, else `"fitted"`.
+    pub source: String,
 }
 
 /// A plan with the instant it was computed — what the shadow loop publishes for the API.
@@ -488,6 +504,10 @@ pub struct PlanCache {
     /// window (see [`fit_live_internal_gains`]) on its own slow cadence and writes them here; absent
     /// that, [`build_cache`] seeds them from the calibrated `heating` config values.
     pub internal_gains: HashMap<String, f64>,
+    /// Fitted scheduled-load magnitudes (W, ≥ 0), aligned 1:1 to `config.scheduled_loads`. The shadow
+    /// loop writes its live re-fit here; [`build_cache`] seeds them to zero (no effect) until the
+    /// first fit lands.
+    pub scheduled_w: Vec<f64>,
 }
 
 /// Build the cacheable slow inputs — the 7-day PV-calibration backtest and the trailing-window
@@ -507,6 +527,13 @@ pub async fn build_cache(db: &SourceClients, config: &ControlConfig) -> PlanCach
         consumption,
         calibration,
         internal_gains: config.heating.internal_gains(),
+        // Configured magnitudes (fixed `power_w` used as-is, fitted loads 0) until the live re-fit
+        // overwrites the fitted ones.
+        scheduled_w: config
+            .scheduled_loads
+            .iter()
+            .map(|l| l.power_w.unwrap_or(0.0))
+            .collect(),
     }
 }
 
@@ -514,10 +541,11 @@ pub async fn build_cache(db: &SourceClients, config: &ControlConfig) -> PlanCach
 /// recorded heating relays — the self-correction that lets the model track changes in occupant
 /// behaviour (more/fewer people, appliance and fireplace use) without any config or model edit.
 ///
-/// Returns `Some(gains)` on a successful fit — including an **empty** map, which is the legitimate
-/// answer "the data shows no extra gain is needed" (e.g. summer, or a fireplace that's stopped being
-/// used), so the caller should trust it. Returns `None` only when the fit can't run (no data /
-/// sensors down), so the caller keeps its last-good gains rather than discarding them.
+/// Returns `Some(fit)` on a successful fit — including **empty** gains, which is the legitimate answer
+/// "the data shows no extra gain is needed" (e.g. summer, or a fireplace that's stopped being used),
+/// so the caller should trust it. The fit also carries the per-scheduled-load magnitudes (W, aligned
+/// to `config.scheduled_loads`). Returns `None` only when the fit can't run (no data / sensors down),
+/// so the caller keeps its last-good values rather than discarding them.
 pub async fn fit_live_internal_gains(
     db: &SourceClients,
     net: &RcNetwork,
@@ -525,7 +553,7 @@ pub async fn fit_live_internal_gains(
     config: &ControlConfig,
     latitude: Angle,
     longitude: Angle,
-) -> Option<HashMap<String, f64>> {
+) -> Option<GainFit> {
     let window_days = config.internal_gain_window_days.max(3);
     let cfg = BacktestConfig {
         warmup_hours: 48, // relax the unknown slab seed before scoring
@@ -533,12 +561,18 @@ pub async fn fit_live_internal_gains(
         ground_temperature_c: config.site.ground_temperature_c,
         cloud_cover: 0.5,
     };
+    let local_offset = match FixedOffset::east_opt(config.site.utc_offset_hours * 3600) {
+        Some(o) => o,
+        None => FixedOffset::east_opt(0).unwrap(),
+    };
     let start = format!("-{window_days}d");
     match validate::fit_internal_gains(
         db,
         net,
         ss,
         &config.heating,
+        &config.scheduled_loads,
+        local_offset,
         latitude,
         longitude,
         &cfg,
@@ -547,7 +581,7 @@ pub async fn fit_live_internal_gains(
     )
     .await
     {
-        Ok(gains) => Some(gains),
+        Ok(fit) => Some(fit),
         Err(e) => {
             eprintln!("[mpc shadow] internal-gain re-fit failed ({e}); keeping previous gains");
             None
@@ -739,6 +773,20 @@ pub async fn current_plan(
         internal_gain_w: cache
             .map(|c| c.internal_gains.clone())
             .unwrap_or_else(|| config.heating.internal_gains()),
+        scheduled_loads: config.scheduled_loads.clone(),
+        // Live-fitted scheduled-load magnitudes from the cache; the on-demand path (no cache) seeds
+        // them from the configured magnitudes (a fixed `power_w` takes effect immediately; a fitted
+        // load is 0, no effect) until the loop's first re-fit lands.
+        scheduled_w: cache
+            .map(|c| c.scheduled_w.clone())
+            .filter(|w| w.len() == config.scheduled_loads.len())
+            .unwrap_or_else(|| {
+                config
+                    .scheduled_loads
+                    .iter()
+                    .map(|l| l.power_w.unwrap_or(0.0))
+                    .collect()
+            }),
         export_price,
         export_allowed: export_allowed.clone(),
         inverter_on: inverter_on.clone(),

--- a/src/estimate.rs
+++ b/src/estimate.rs
@@ -9,7 +9,7 @@
 use std::collections::HashMap;
 
 use anyhow::{ensure, Context, Result};
-use chrono::{DateTime, Duration, TimeZone, Utc};
+use chrono::{DateTime, Datelike, Duration, TimeZone, Timelike, Utc};
 use nalgebra::DVector;
 use uom::si::{
     f64::{Angle, Power, Ratio, ThermodynamicTemperature},
@@ -78,6 +78,16 @@ pub struct DriveData {
     /// Constant per-zone internal heat gain (W) — occupants, appliances, cooking, fireplace — that
     /// the physics model doesn't otherwise have. Injected at each zone's air node in [`drive`].
     pub internal_gain_w: HashMap<String, f64>,
+    /// Scheduled heat fluxes (e.g. a water heat-pump that cools its room on a seasonal schedule) —
+    /// only the direction + schedule; the magnitude is `scheduled_w`. Applied at each load's zone air
+    /// node in [`drive`] as `scheduled_w[i] × unit_profile(local time)`, combined with the internal
+    /// gain on the same node. Empty = none.
+    pub scheduled_loads: Vec<crate::optimize::config::ScheduledLoad>,
+    /// Fitted magnitude (W, ≥ 0) of each [`Self::scheduled_loads`] entry, aligned 1:1. The probe in
+    /// [`crate::validate::fit_gains`] overwrites a single entry to measure its response.
+    pub scheduled_w: Vec<f64>,
+    /// Site-local civil-time offset, for evaluating the scheduled-load windows (month / minute-of-day).
+    pub local_offset: chrono::FixedOffset,
 }
 
 /// Read the measured outside temperature and open-meteo cloud cover over `[start, now]` onto an
@@ -138,6 +148,9 @@ pub async fn read_drive_data(
         ground_c,
         heating_kw: HashMap::new(),
         internal_gain_w: HashMap::new(),
+        scheduled_loads: Vec::new(),
+        scheduled_w: Vec::new(),
+        local_offset: chrono::FixedOffset::east_opt(0).unwrap(),
     })
 }
 
@@ -256,11 +269,24 @@ pub fn drive(
                 }
             }
         }
-        // Constant internal gains (occupants / appliances / fireplace) at each zone's air node — a
-        // node distinct from the heating markers and solar surfaces, so this never overwrites them.
+        // Combined per-zone air-node flux: the constant internal gain (occupants / appliances /
+        // fireplace) plus any scheduled loads active now (e.g. a water heat-pump that cools its room
+        // on a seasonal schedule). The air node is distinct from the heating markers and solar
+        // surfaces, so this never overwrites them; accumulating into one map then writing once means
+        // an internal gain and a scheduled load on the same zone *combine* rather than clobber.
+        let local = when.with_timezone(&data.local_offset);
+        let (month, minute) = (local.month(), local.hour() * 60 + local.minute());
+        let mut air_flux_w: HashMap<&str, f64> = HashMap::new();
         for (zone, &gain_w) in &data.internal_gain_w {
+            *air_flux_w.entry(zone.as_str()).or_insert(0.0) += gain_w;
+        }
+        for (load, &w) in data.scheduled_loads.iter().zip(&data.scheduled_w) {
+            *air_flux_w.entry(load.zone.as_str()).or_insert(0.0) +=
+                w * load.unit_profile(month, minute);
+        }
+        for (zone, flux_w) in air_flux_w {
             if let Some(&node) = net.zone_indices.get(zone) {
-                ss.set_flux(&mut u, node, Power::new::<watt>(gain_w));
+                ss.set_flux(&mut u, node, Power::new::<watt>(flux_w));
             }
         }
         x = ss.step(&disc, &x, &u);

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,11 +292,15 @@ async fn run_backtest_heating(
         ground_temperature_c: config.site.ground_temperature_c,
         cloud_cover: 0.5,
     };
-    let (before, after, gains) = validate::calibrate_internal_gains(
+    let local_offset = chrono::FixedOffset::east_opt(config.site.utc_offset_hours * 3600)
+        .expect("site.utc_offset_hours validated at config load");
+    let (before, after, fit) = validate::calibrate_internal_gains(
         &db,
         &rcnet,
         &ss,
         &config.heating,
+        &config.scheduled_loads,
+        local_offset,
         lat,
         lon,
         &cfg,
@@ -304,6 +308,7 @@ async fn run_backtest_heating(
         stop,
     )
     .await?;
+    let gains = fit.gains;
     println!(
         "\nActive heating backtest {start} .. {stop}  (scored last {} h after {warmup_hours} h warm-up,\nmodel driven by the recorded per-zone heating relays + measured outside temp + solar):",
         cfg.window_hours,
@@ -339,6 +344,19 @@ async fn run_backtest_heating(
         mean(&before),
         mean(&after),
     );
+    // Fitted scheduled-load magnitudes (e.g. the water heat-pump): only the schedule + direction are
+    // configured; the magnitude is learnt here.
+    for (load, &w) in config.scheduled_loads.iter().zip(&fit.scheduled_w) {
+        let label = if load.label.is_empty() {
+            load.zone.as_str()
+        } else {
+            load.label.as_str()
+        };
+        println!(
+            "  scheduled load '{label}' ({:?}, zone {}): fitted magnitude {w:.0} W",
+            load.kind, load.zone,
+        );
+    }
     Ok(())
 }
 
@@ -641,6 +659,8 @@ fn demo_plan() {
         ground_temperature_c: 12.0,
         cloud_cover: vec![0.2; 24],
         internal_gain_w: Default::default(), // battery-only demo: thermal side unused
+        scheduled_loads: Vec::new(),
+        scheduled_w: Vec::new(),
         export_price: import_price.iter().map(|p| p * 0.3).collect(),
         export_allowed: vec![true; 24],
         inverter_on: vec![true; 24],
@@ -713,6 +733,8 @@ fn demo_heating(rcnet: &RcNetwork, ss: &StateSpace) -> anyhow::Result<()> {
         ground_temperature_c: 8.0,
         cloud_cover: vec![0.8; horizon],
         internal_gain_w: config.heating.internal_gains(),
+        scheduled_loads: config.scheduled_loads.clone(),
+        scheduled_w: vec![0.0; config.scheduled_loads.len()],
         export_price: import_price.iter().map(|p| p * 0.3).collect(),
         export_allowed: vec![true; 24],
         inverter_on: vec![true; 24],

--- a/src/mpc_loop.rs
+++ b/src/mpc_loop.rs
@@ -16,7 +16,7 @@ use chrono::{DateTime, Utc};
 
 use crate::app::{
     build_cache, current_plan, fit_live_internal_gains, GainsSnapshot, PlanCache, PlanReport,
-    TimestampedPlan,
+    ScheduledFit, TimestampedPlan,
 };
 use crate::forecast_validation::{append_snapshot, Snapshot};
 use crate::tools::sort_desc_by_key;
@@ -41,8 +41,18 @@ pub async fn run(state: Arc<AppState>, tick: Duration) {
 
     // Live internal-gain self-correction: re-fit from a trailing window on a slow cadence (the gains
     // drift only as occupant behaviour does), seeded from the calibrated config values until the
-    // first fit lands. `internal_gain_recalibrate_hours == 0` pins them to the config values.
+    // first fit lands. `internal_gain_recalibrate_hours == 0` pins them to the config values. The same
+    // fit learns each scheduled load's magnitude (W), held alongside the gains and stamped into the
+    // cache so the plan applies it.
     let mut gains: HashMap<String, f64> = state.config.heating.internal_gains();
+    // Seed with the configured magnitudes (a fixed `power_w` is used as-is; a fitted load starts at 0)
+    // so the plan applies the known draws even before the first re-fit lands.
+    let mut scheduled_w: Vec<f64> = state
+        .config
+        .scheduled_loads
+        .iter()
+        .map(|l| l.power_w.unwrap_or(0.0))
+        .collect();
     let mut gains_at: Option<Instant> = None; // last *successful* re-fit
     let mut last_attempt: Option<Instant> = None; // last attempt (gates the failure back-off)
     let gain_interval = Duration::from_secs(
@@ -78,13 +88,48 @@ pub async fn run(state: Arc<AppState>, tick: Duration) {
             )
             .await
             {
-                log_gains(&fitted);
-                gains = fitted;
+                log_gains(&fitted.gains);
+                gains = fitted.gains;
+                // Align defensively to the configured load count (the fit returns exactly that). On a
+                // length mismatch, fall back to the configured magnitudes (fixed used as-is, fitted 0).
+                scheduled_w = if fitted.scheduled_w.len() == state.config.scheduled_loads.len() {
+                    fitted.scheduled_w
+                } else {
+                    state
+                        .config
+                        .scheduled_loads
+                        .iter()
+                        .map(|l| l.power_w.unwrap_or(0.0))
+                        .collect()
+                };
                 gains_at = Some(Instant::now());
+                // Surface each scheduled-load magnitude in use, tagged configured vs fitted, for
+                // `/api/calibration/gains` → `live.scheduled`.
+                let scheduled: Vec<ScheduledFit> = state
+                    .config
+                    .scheduled_loads
+                    .iter()
+                    .zip(&scheduled_w)
+                    .map(|(load, &w)| ScheduledFit {
+                        label: if load.label.is_empty() {
+                            load.zone.clone()
+                        } else {
+                            load.label.clone()
+                        },
+                        zone: load.zone.clone(),
+                        magnitude_w: w,
+                        source: if load.power_w.is_some() {
+                            "configured".to_string()
+                        } else {
+                            "fitted".to_string()
+                        },
+                    })
+                    .collect();
                 *state.gains.lock().unwrap_or_else(|e| e.into_inner()) = Some(GainsSnapshot {
                     fitted_at: Utc::now(),
                     window_days: state.config.internal_gain_window_days,
                     gains_w: gains.clone(),
+                    scheduled,
                 });
             }
         }
@@ -94,9 +139,11 @@ pub async fn run(state: Arc<AppState>, tick: Duration) {
         if cache.as_ref().is_none_or(|(t, _)| t.elapsed() >= CACHE_TTL) {
             cache = Some((Instant::now(), build_cache(&state.db, &state.config).await));
         }
-        // Stamp the current live gains into the cache so the plan uses them (cheap map clone).
+        // Stamp the current live gains + scheduled-load magnitudes into the cache so the plan uses
+        // them (cheap clones).
         if let Some((_, c)) = cache.as_mut() {
             c.internal_gains = gains.clone();
+            c.scheduled_w = scheduled_w.clone();
         }
         let cached = cache.as_ref().map(|(_, c)| c);
 

--- a/src/optimize/config.rs
+++ b/src/optimize/config.rs
@@ -42,6 +42,12 @@ pub struct ControlConfig {
     /// See [`DataSources`] and `docs/data-sources.md`.
     #[serde(default)]
     pub data_sources: DataSources,
+    /// Scheduled heat fluxes at a zone's air node — known appliances on a daily/seasonal schedule the
+    /// physics model has no source for (e.g. a water heat-pump that cools its room while it runs, or a
+    /// fireplace). Only the **direction** (sink/source) and the **schedule** are configured; the live
+    /// calibration *learns the magnitude* from data. Empty ⇒ none. See `docs/configuration.md`.
+    #[serde(default)]
+    pub scheduled_loads: Vec<ScheduledLoad>,
     /// How far back to train the consumption model from measured history (days).
     #[serde(default = "default_consumption_history_days")]
     pub consumption_history_days: i64,
@@ -64,6 +70,94 @@ pub struct ControlConfig {
     /// snapshotting. Stored to a JSON file (`MPC_FORECAST_STORE`, default `forecast_snapshots.json`).
     #[serde(default = "default_forecast_snapshot_minutes")]
     pub forecast_snapshot_minutes: u64,
+}
+
+/// A scheduled heat flux applied at a zone's air node — an appliance the physics model has no source
+/// for, active on configured local-time windows. The magnitude is either **configured** (`power_w`
+/// set — a known draw) or **fitted** (`power_w` omitted — the calibration learns it from data); the
+/// sign is fixed by [`LoadKind`] either way, so the house always declares *when* and *which way*. The
+/// model then applies `magnitude_w × unit_profile` as an extra flux, in both the optimizer prediction
+/// and the calibration drive.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ScheduledLoad {
+    /// Zone whose air node the flux is applied at.
+    pub zone: String,
+    /// Display label (e.g. "water heat-pump"). Optional.
+    #[serde(default)]
+    pub label: String,
+    /// Direction: a `sink` removes heat (cools the room — e.g. a heat-pump heating a tank from room
+    /// air); a `source` adds heat. Fixes the sign of the magnitude.
+    pub kind: LoadKind,
+    /// Magnitude (W, > 0) when the draw is **known**: the model uses it as-is and the calibration does
+    /// not fit it. Omit to have the calibration **learn** it from data (the default). The sign always
+    /// comes from `kind` — this is the unsigned watts.
+    #[serde(default)]
+    pub power_w: Option<f64>,
+    /// Local-time windows the load is active in. Empty ⇒ never active.
+    pub windows: Vec<LoadWindow>,
+}
+
+/// The direction of a [`ScheduledLoad`] — the sign of its (fitted, non-negative) magnitude.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LoadKind {
+    /// Removes heat from the zone (negative flux).
+    Sink,
+    /// Adds heat to the zone (positive flux).
+    Source,
+}
+
+/// One active window of a [`ScheduledLoad`], in site-local civil time.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LoadWindow {
+    /// Months (1-12) the window applies to. Empty ⇒ every month.
+    #[serde(default)]
+    pub months: Vec<u32>,
+    /// Local start time, `"HH:MM"` (inclusive).
+    pub start: String,
+    /// Local end time, `"HH:MM"` (exclusive). An end ≤ start wraps past midnight (e.g. `22:00`→`06:00`).
+    pub end: String,
+}
+
+impl ScheduledLoad {
+    /// The **unit** signed profile at a site-local instant: `-1.0` for an active sink, `+1.0` for an
+    /// active source, `0.0` when no window is active. The calibration scales this by the fitted
+    /// magnitude (W, ≥ 0); the model applies `magnitude × unit_profile` as the flux.
+    pub fn unit_profile(&self, month: u32, minute_of_day: u32) -> f64 {
+        if self
+            .windows
+            .iter()
+            .any(|w| w.contains(month, minute_of_day))
+        {
+            match self.kind {
+                LoadKind::Sink => -1.0,
+                LoadKind::Source => 1.0,
+            }
+        } else {
+            0.0
+        }
+    }
+}
+
+impl LoadWindow {
+    /// Whether this window is active at the given month (1-12) and minute-of-day (0-1439), local.
+    pub fn contains(&self, month: u32, minute_of_day: u32) -> bool {
+        if !self.months.is_empty() && !self.months.contains(&month) {
+            return false;
+        }
+        match (parse_hm(&self.start), parse_hm(&self.end)) {
+            (Some(s), Some(e)) if s < e => (s..e).contains(&minute_of_day), // same-day window
+            (Some(s), Some(e)) => minute_of_day >= s || minute_of_day < e,  // wraps past midnight
+            _ => false, // unparseable ⇒ inactive (rejected at load by validate_scheduled_loads)
+        }
+    }
+}
+
+/// Parse `"HH:MM"` to a minute-of-day (0-1439); `None` if malformed or out of range.
+fn parse_hm(s: &str) -> Option<u32> {
+    let (h, m) = s.split_once(':')?;
+    let (h, m): (u32, u32) = (h.trim().parse().ok()?, m.trim().parse().ok()?);
+    (h < 24 && m < 60).then_some(h * 60 + m)
 }
 
 /// Home-battery specification (mirrors the loxone Growatt settings).
@@ -912,6 +1006,42 @@ impl ControlConfig {
         Ok(())
     }
 
+    /// Reject malformed scheduled loads at load: every window time must parse as `HH:MM` and every
+    /// month must be 1-12, so a typo fails fast instead of silently never firing (see
+    /// [`LoadWindow::contains`]'s defensive `false`).
+    fn validate_scheduled_loads(&self) -> Result<()> {
+        for load in &self.scheduled_loads {
+            anyhow::ensure!(
+                !load.windows.is_empty(),
+                "scheduled_load for zone {:?} has no windows (it would never fire)",
+                load.zone
+            );
+            if let Some(w) = load.power_w {
+                anyhow::ensure!(
+                    w.is_finite() && w > 0.0,
+                    "scheduled_load zone {:?}: power_w must be finite and > 0 (got {w}); omit it to auto-fit",
+                    load.zone
+                );
+            }
+            for w in &load.windows {
+                anyhow::ensure!(
+                    parse_hm(&w.start).is_some() && parse_hm(&w.end).is_some(),
+                    "scheduled_load zone {:?}: window time must be \"HH:MM\" (got {:?}–{:?})",
+                    load.zone,
+                    w.start,
+                    w.end
+                );
+                anyhow::ensure!(
+                    w.months.iter().all(|m| (1..=12).contains(m)),
+                    "scheduled_load zone {:?}: months must be 1-12 (got {:?})",
+                    load.zone,
+                    w.months
+                );
+            }
+        }
+        Ok(())
+    }
+
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
         let cfg = Self::from_json5(&std::fs::read_to_string(path)?)?;
         cfg.validate_chargers()?;
@@ -924,6 +1054,7 @@ impl ControlConfig {
             hvac.validate()?;
         }
         cfg.validate_site()?;
+        cfg.validate_scheduled_loads()?;
         Ok(cfg)
     }
 }
@@ -931,6 +1062,110 @@ impl ControlConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn win(months: &[u32], start: &str, end: &str) -> LoadWindow {
+        LoadWindow {
+            months: months.to_vec(),
+            start: start.into(),
+            end: end.into(),
+        }
+    }
+
+    #[test]
+    fn load_window_same_day_is_half_open() {
+        let w = win(&[], "10:00", "14:00");
+        assert!(!w.contains(7, 9 * 60 + 59)); // before start
+        assert!(w.contains(7, 10 * 60)); // start inclusive
+        assert!(w.contains(7, 13 * 60 + 59));
+        assert!(!w.contains(7, 14 * 60)); // end exclusive
+    }
+
+    #[test]
+    fn load_window_wraps_past_midnight() {
+        let w = win(&[], "22:00", "06:00");
+        assert!(w.contains(1, 23 * 60)); // late evening
+        assert!(w.contains(1, 60)); // small hours (01:00)
+        assert!(w.contains(1, 0)); // midnight
+        assert!(!w.contains(1, 6 * 60)); // end exclusive
+        assert!(!w.contains(1, 12 * 60)); // midday is outside
+    }
+
+    #[test]
+    fn load_window_gates_on_month() {
+        let w = win(&[5, 6, 7, 8, 9], "10:00", "20:00");
+        assert!(w.contains(7, 12 * 60)); // July, in window
+        assert!(!w.contains(1, 12 * 60)); // January, wrong month
+    }
+
+    #[test]
+    fn unit_profile_signs_and_season() {
+        // The real heat-pump: a summer-daytime / winter-overnight sink in technical_room.
+        let hp = ScheduledLoad {
+            zone: "technical_room".into(),
+            label: "water heat-pump".into(),
+            kind: LoadKind::Sink,
+            power_w: None,
+            windows: vec![
+                win(&[5, 6, 7, 8, 9], "10:00", "20:00"),
+                win(&[10, 11, 12, 1, 2, 3, 4], "01:00", "05:00"),
+            ],
+        };
+        assert_eq!(hp.unit_profile(7, 12 * 60), -1.0); // summer midday: cooling
+        assert_eq!(hp.unit_profile(7, 6 * 60), 0.0); // summer early morning: off
+        assert_eq!(hp.unit_profile(1, 2 * 60), -1.0); // winter night: cooling
+        assert_eq!(hp.unit_profile(1, 12 * 60), 0.0); // winter midday: off
+                                                      // A source flips the sign.
+        let src = ScheduledLoad {
+            kind: LoadKind::Source,
+            ..hp
+        };
+        assert_eq!(src.unit_profile(7, 12 * 60), 1.0);
+    }
+
+    #[test]
+    fn validate_scheduled_loads_rejects_malformed() {
+        let ok = ControlConfig::from_json5(
+            r#"{ site:{latitude:50,longitude:14,utc_offset_hours:1},
+                 heating:{cop:1,comfort_penalty:0,zones:{}},
+                 scheduled_loads:[{zone:"x",kind:"sink",windows:[{start:"01:00",end:"05:00"}]}] }"#,
+        )
+        .unwrap();
+        assert!(ok.validate_scheduled_loads().is_ok());
+
+        let bad_time = ControlConfig::from_json5(
+            r#"{ site:{latitude:50,longitude:14,utc_offset_hours:1},
+                 heating:{cop:1,comfort_penalty:0,zones:{}},
+                 scheduled_loads:[{zone:"x",kind:"sink",windows:[{start:"25:00",end:"05:00"}]}] }"#,
+        )
+        .unwrap();
+        assert!(bad_time.validate_scheduled_loads().is_err());
+
+        let no_windows = ControlConfig::from_json5(
+            r#"{ site:{latitude:50,longitude:14,utc_offset_hours:1},
+                 heating:{cop:1,comfort_penalty:0,zones:{}},
+                 scheduled_loads:[{zone:"x",kind:"source",windows:[]}] }"#,
+        )
+        .unwrap();
+        assert!(no_windows.validate_scheduled_loads().is_err());
+
+        // A configured `power_w` must be finite and > 0; a non-positive value is rejected.
+        let fixed_ok = ControlConfig::from_json5(
+            r#"{ site:{latitude:50,longitude:14,utc_offset_hours:1},
+                 heating:{cop:1,comfort_penalty:0,zones:{}},
+                 scheduled_loads:[{zone:"x",kind:"sink",power_w:800,windows:[{start:"01:00",end:"05:00"}]}] }"#,
+        )
+        .unwrap();
+        assert_eq!(fixed_ok.scheduled_loads[0].power_w, Some(800.0));
+        assert!(fixed_ok.validate_scheduled_loads().is_ok());
+
+        let bad_power = ControlConfig::from_json5(
+            r#"{ site:{latitude:50,longitude:14,utc_offset_hours:1},
+                 heating:{cop:1,comfort_penalty:0,zones:{}},
+                 scheduled_loads:[{zone:"x",kind:"sink",power_w:0,windows:[{start:"01:00",end:"05:00"}]}] }"#,
+        )
+        .unwrap();
+        assert!(bad_power.validate_scheduled_loads().is_err());
+    }
 
     #[test]
     fn tariff_validate_rejects_inverted_economics() {

--- a/src/optimize/coordinator.rs
+++ b/src/optimize/coordinator.rs
@@ -23,7 +23,7 @@ use uom::si::{
 };
 
 use super::battery::{optimize_dispatch, BatterySpec, DispatchInputs, DispatchPlan};
-use super::config::{HeatingConfig, HvacConfig};
+use super::config::{HeatingConfig, HvacConfig, ScheduledLoad};
 use super::thermal::build_context;
 use super::unified::{optimize_unified, EvSpec, FlowParams, UnifiedPlan};
 use crate::forecast::consumption::ConsumptionModel;
@@ -59,6 +59,15 @@ pub struct ForecastContext {
     /// [`crate::validate::calibrate_internal_gains`]; empty = none. Keeps the live forecast from
     /// running cold in rooms with unmodelled gains (kitchen cooking, livingroom fireplace).
     pub internal_gain_w: HashMap<String, f64>,
+    /// Scheduled heat fluxes at a zone's air node (e.g. a water heat-pump that cools its room on a
+    /// seasonal schedule) — only the direction + schedule; the magnitude is [`Self::scheduled_w`].
+    /// Applied at each load's zone air node alongside the internal gain, evaluated at the block's
+    /// local time. Empty = none.
+    pub scheduled_loads: Vec<ScheduledLoad>,
+    /// Fitted magnitude (W, ≥ 0) of each [`Self::scheduled_loads`] entry, aligned 1:1 (the calibration
+    /// learns it; see [`crate::validate::fit_gains`]). Empty or shorter than `scheduled_loads` ⇒ the
+    /// missing entries contribute nothing.
+    pub scheduled_w: Vec<f64>,
     /// Grid import price (price-units per kWh) per hour.
     pub import_price: Vec<f64>,
     /// Grid export / feed-in price (price-units per kWh) per block.
@@ -217,9 +226,22 @@ fn known_thermal_inputs(
             );
             ss.set_flux(&mut u, surf.node, irradiance * surf.area);
         }
+        // Combined per-zone air-node flux: the constant internal gain plus any scheduled loads active
+        // at this block's local time (their fitted magnitude × signed unit profile). Accumulate into
+        // one map then write once per zone so a gain and a scheduled load on the same air node combine.
+        let local = block_midpoint(ctx, h).with_timezone(&ctx.local_offset);
+        let (month, minute) = (local.month(), local.hour() * 60 + local.minute());
+        let mut air_flux_w: HashMap<&str, f64> = HashMap::new();
         for (zone, &gain_w) in &ctx.internal_gain_w {
+            *air_flux_w.entry(zone.as_str()).or_insert(0.0) += gain_w;
+        }
+        for (load, &w) in ctx.scheduled_loads.iter().zip(&ctx.scheduled_w) {
+            *air_flux_w.entry(load.zone.as_str()).or_insert(0.0) +=
+                w * load.unit_profile(month, minute);
+        }
+        for (zone, flux_w) in air_flux_w {
             if let Some(&node) = net.zone_indices.get(zone) {
-                ss.set_flux(&mut u, node, Power::new::<watt>(gain_w));
+                ss.set_flux(&mut u, node, Power::new::<watt>(flux_w));
             }
         }
         u_known.push(u);
@@ -360,6 +382,8 @@ mod tests {
             ground_temperature_c: 10.0,
             cloud_cover: vec![0.0; 24],
             internal_gain_w: HashMap::new(),
+            scheduled_loads: Vec::new(),
+            scheduled_w: Vec::new(),
             import_price: vec![0.20; 24],
             export_price: vec![0.05; 24],
             export_allowed: vec![true; 24],
@@ -404,6 +428,8 @@ mod tests {
             ground_temperature_c: 10.0,
             cloud_cover: vec![0.0; 3],
             internal_gain_w: HashMap::new(),
+            scheduled_loads: Vec::new(),
+            scheduled_w: Vec::new(),
             import_price: vec![0.2; 3],
             export_price: vec![0.05; 3],
             export_allowed: vec![true; 3],
@@ -532,6 +558,8 @@ mod tests {
             ground_temperature_c: 8.0,
             cloud_cover: vec![0.8; n],
             internal_gain_w: HashMap::new(),
+            scheduled_loads: Vec::new(),
+            scheduled_w: Vec::new(),
             import_price: (0..n).map(|h| if h < n / 2 { 0.1 } else { 0.5 }).collect(),
             export_price: vec![0.03; n],
             export_allowed: vec![true; n],

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -26,13 +26,14 @@
 use std::collections::HashMap;
 
 use anyhow::{ensure, Result};
+use chrono::FixedOffset;
 use uom::si::f64::Angle;
 
 use nalgebra::DVector;
 
 use crate::estimate::{drive, hour_key, read_drive_data, resample_ffill, seed_state, DriveData};
 use crate::influxdb::TimeSample;
-use crate::optimize::config::HeatingConfig;
+use crate::optimize::config::{HeatingConfig, ScheduledLoad};
 use crate::rc_network::RcNetwork;
 use crate::source::SourceClients;
 use crate::state_space::StateSpace;
@@ -253,12 +254,17 @@ fn nnls(a: &[Vec<f64>], b: &[f64], cols: usize) -> Vec<f64> {
 
 /// Read everything an active (heating-on) fit/backtest needs over `[start, stop]`: the driving data
 /// (outside temp + cloud), the **recorded per-zone heating relays**, the measured seed state, and the
-/// measured per-zone temperature series. The returned `DriveData` has **no** internal gains set.
+/// measured per-zone temperature series. The returned `DriveData` carries the scheduled loads with
+/// their **fixed** (`power_w`) magnitudes applied and the fitted ones at 0 (the probe driver in
+/// [`fit_gains`] sets those), plus the site `local_offset`, but **no** internal gains.
+#[allow(clippy::too_many_arguments)] // db, model, heating, loads, offset, cfg and time bounds are all distinct
 async fn load_active(
     db: &SourceClients,
     net: &RcNetwork,
     ss: &StateSpace,
     heating: &HeatingConfig,
+    scheduled_loads: &[ScheduledLoad],
+    local_offset: FixedOffset,
     cfg: &BacktestConfig,
     start: &str,
     stop: &str,
@@ -267,17 +273,47 @@ async fn load_active(
     let mut data =
         read_drive_data(db, start, stop, cfg.ground_temperature_c, cfg.cloud_cover).await?;
     data.heating_kw = read_heating_kw(db, net, heating, &data.hours, start, stop).await;
+    data.scheduled_loads = scheduled_loads.to_vec();
+    // Fixed loads (`power_w`) applied at their configured magnitude; fitted loads start at 0 (the fit
+    // probe sets those). So the `before` score and the fit baseline both include the known draws.
+    data.scheduled_w = scheduled_loads
+        .iter()
+        .map(|l| l.power_w.unwrap_or(0.0))
+        .collect();
+    data.local_offset = local_offset;
     let (x0, zone_series) = seed_state(db, net, ss, start, stop).await?;
     Ok((data, x0, zone_series))
 }
 
-/// The coupled NNLS fit of per-zone internal gains (W), pure (no IO). The model is LTI, so the zones'
-/// window-mean temperatures are jointly *affine* in the gain vector: drive with no gains to get each
-/// zone's bias, probe each *cold* zone with a unit gain to measure the full (coupled) response, and
-/// solve `response·g = −bias` with non-negative least squares. Fitting zones independently would
-/// overheat small rooms via their big neighbours' leakage through shared walls; the joint fit doesn't.
-/// `data` must carry the recorded heating and **no** internal gains. Scores over the last `window` h.
-#[allow(clippy::too_many_arguments)] // model, site, state, data, series and window are all distinct
+/// The result of the coupled fit: per-zone constant internal gains (W) and the fitted magnitude of
+/// each scheduled load (W, ≥ 0), aligned 1:1 to the loads passed into [`fit_gains`].
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct GainFit {
+    /// Per-zone constant internal gain (W) — only the zones the fit kept (≥ `MIN_GAIN_W`).
+    pub gains: HashMap<String, f64>,
+    /// Fitted magnitude (W, ≥ 0) of each scheduled load, aligned to the input `scheduled_loads`
+    /// (`0.0` for a load that was dropped as too weakly coupled or fit to nothing).
+    pub scheduled_w: Vec<f64>,
+}
+
+/// The coupled NNLS fit of per-zone internal gains (W) **and** scheduled-load magnitudes (W), pure
+/// (no IO). The model is LTI, so each zone's per-hour residual trajectory is jointly *affine* in the
+/// gain/magnitude vector. We fit that **trajectory** (one row per (zone, hour) with measured data),
+/// not just each zone's window mean: against a single mean a flat internal gain and a time-localized
+/// scheduled load are collinear, but against the trajectory the load's distinctive on/off shape
+/// separates it from the always-on gain.
+///
+/// Drive with no fitted gains and the **fixed** scheduled loads at their configured magnitude for the
+/// baseline; probe each *cold* zone (negative mean residual) with a unit internal gain and each
+/// **fitted** scheduled load with a unit magnitude to measure their full (coupled) response (one
+/// column each); then solve `column·c = target` with non-negative least squares. A **fixed** load
+/// (`power_w` set) is a known input, not a candidate: it's applied at its configured magnitude in the
+/// baseline drive *and* every probe, so the fit explains only what's left over it. Fitting zones
+/// independently would overheat small rooms via their big neighbours' leakage through shared walls;
+/// the joint fit doesn't. `data` must carry the recorded heating, **no** internal gains, and the
+/// loads' `zone`/`local_offset`; its `scheduled_w` is ignored — the baseline and every probe rebuild
+/// the fixed magnitudes from each load's `power_w`. Scores over the last `window` h.
+#[allow(clippy::too_many_arguments)] // model, site, state, data, series, loads, offset and window are all distinct
 fn fit_gains(
     net: &RcNetwork,
     ss: &StateSpace,
@@ -286,94 +322,213 @@ fn fit_gains(
     x0: &DVector<f64>,
     data: &DriveData,
     zone_series: &HashMap<String, Vec<TimeSample>>,
+    scheduled_loads: &[ScheduledLoad],
     window: usize,
-) -> HashMap<String, f64> {
-    let bias = |traj: &[DVector<f64>]| -> HashMap<String, f64> {
-        score_zones(net, ss, traj, &data.hours, zone_series, window)
-            .into_iter()
-            .map(|z| (z.zone, z.mean_bias_k))
-            .collect()
-    };
-    let bias0 = bias(&drive(net, ss, latitude, longitude, x0, data));
-
+    local_offset: FixedOffset,
+) -> GainFit {
     const PROBE_W: f64 = 500.0;
-    // A candidate is kept only if its own gain moves its own window-mean by at least this (K per W).
-    // A zone barely coupled to its gain (a sealed, well-insulated room) is *unidentifiable*: a tiny
-    // self-response would let the solver assign an absurd gain to explain a small bias (≈ bias /
-    // self-response). 1e-3 K/W ⇒ ≥0.5 K per 500 W probe — far below any real slab-heated zone (~10×).
+    // A candidate is kept only if it moves some row by at least this (K per W). A zone barely coupled
+    // to its gain (a sealed, well-insulated room) — or a scheduled load whose window doesn't overlap
+    // the fit window — is *unidentifiable*: a tiny response would let the solver assign an absurd
+    // coefficient to explain a small residual. 1e-3 K/W ⇒ ≥0.5 K per 500 W probe.
     const MIN_SELF_RESPONSE: f64 = 1e-3;
+    const MIN_GAIN_W: f64 = 1.0;
 
+    // A **fixed** load (`power_w` set) is a known input applied at its configured magnitude in the
+    // baseline drive and every probe; a **fitted** load (`power_w` None) is 0 here and becomes a
+    // candidate below. The baseline and probes all start from this vector, so the fit explains only the
+    // residual the fixed loads leave behind.
+    let fixed_w: Vec<f64> = scheduled_loads
+        .iter()
+        .map(|l| l.power_w.unwrap_or(0.0))
+        .collect();
+
+    // Fixed row layout: every (zone, hour) over the last `window` hours where a measured value exists.
+    // `predicted_rows` reads a trajectory at exactly those (state_row, hour) cells, so every column
+    // and the target share one index space.
     let mut zones: Vec<String> = zone_series.keys().cloned().collect();
     zones.sort();
-    let bias0_vec: Vec<f64> = zones
-        .iter()
-        .map(|z| bias0.get(z).copied().unwrap_or(0.0))
-        .collect();
-    let index_of: HashMap<&str, usize> = zones
-        .iter()
-        .enumerate()
-        .map(|(i, z)| (z.as_str(), i))
-        .collect();
-
-    // Candidate gains are the cold zones (negative bias); already-warm zones get none (you can't
-    // remove internal heat) but still constrain the fit through their rows in the response matrix.
-    // Probe each cold zone with a unit gain to measure the full coupled response (one column), then
-    // drop the unidentifiable ones (negligible self-response) before solving.
-    let mut cand: Vec<String> = Vec::new();
-    let mut columns: Vec<Vec<f64>> = Vec::new();
-    for (zone, &b0) in zones.iter().zip(&bias0_vec) {
-        if b0 >= 0.0 {
+    struct Row {
+        zone: usize, // index into `zones`
+        state_row: usize,
+        hour: usize, // index into `data.hours`
+        measured: f64,
+    }
+    let n_hours = data.hours.len();
+    let win_start = n_hours.saturating_sub(window);
+    let mut rows: Vec<Row> = Vec::new();
+    for (zi, zone) in zones.iter().enumerate() {
+        let Some(state_row) = net.zone_indices.get(zone).and_then(|&n| ss.state_index(n)) else {
             continue;
+        };
+        let measured = align(&data.hours, &zone_series[zone]);
+        for hour in win_start..n_hours {
+            if let Some(m) = measured.get(hour).copied().flatten() {
+                rows.push(Row {
+                    zone: zi,
+                    state_row,
+                    hour,
+                    measured: m,
+                });
+            }
+        }
+    }
+    // Read a driven trajectory at each row's (state_row, hour) cell, in °C.
+    let predicted_rows = |traj: &[DVector<f64>]| -> Vec<f64> {
+        rows.iter()
+            .map(|r| {
+                traj.get(r.hour)
+                    .map(|x| k_to_c(x[r.state_row]))
+                    .unwrap_or(0.0)
+            })
+            .collect::<Vec<f64>>()
+    };
+
+    // Baseline: no fitted gains, fixed loads applied at their configured magnitude. Build the drive
+    // explicitly (with the loads + fixed magnitudes + offset) rather than trusting `data` to carry
+    // them, so the baseline matches every probe's known-input state.
+    let mut baseline = data.clone();
+    baseline.internal_gain_w = HashMap::new();
+    baseline.scheduled_loads = scheduled_loads.to_vec();
+    baseline.scheduled_w = fixed_w.clone();
+    baseline.local_offset = local_offset;
+    let baseline_pred = predicted_rows(&drive(net, ss, latitude, longitude, x0, &baseline));
+    let target: Vec<f64> = rows
+        .iter()
+        .zip(&baseline_pred)
+        .map(|(r, &p)| r.measured - p)
+        .collect();
+    // Per-zone mean baseline residual (predicted − measured): a cold zone (negative) gets an
+    // internal-gain candidate; warm zones constrain the fit through their rows only.
+    let mut zone_resid_sum = vec![0.0_f64; zones.len()];
+    let mut zone_resid_n = vec![0_usize; zones.len()];
+    for (r, &p) in rows.iter().zip(&baseline_pred) {
+        zone_resid_sum[r.zone] += p - r.measured;
+        zone_resid_n[r.zone] += 1;
+    }
+    let column_of = |probe: &DriveData| -> Vec<f64> {
+        let pred = predicted_rows(&drive(net, ss, latitude, longitude, x0, probe));
+        pred.iter()
+            .zip(&baseline_pred)
+            .map(|(p, b)| (p - b) / PROBE_W)
+            .collect::<Vec<f64>>()
+    };
+
+    // Candidate columns, in a fixed order: constant gains (cold zones) first, then scheduled loads.
+    let mut columns: Vec<Vec<f64>> = Vec::new();
+    let mut gain_zones: Vec<String> = Vec::new();
+    for (zi, zone) in zones.iter().enumerate() {
+        let mean_resid = if zone_resid_n[zi] > 0 {
+            zone_resid_sum[zi] / zone_resid_n[zi] as f64
+        } else {
+            0.0
+        };
+        if mean_resid >= 0.0 {
+            continue; // already warm — can't remove internal heat
         }
         let mut probe = data.clone();
         probe.internal_gain_w = HashMap::from([(zone.clone(), PROBE_W)]);
-        let probed = bias(&drive(net, ss, latitude, longitude, x0, &probe));
-        // column[i] = °C window-mean shift in zone i per watt of internal gain in this zone.
-        let column: Vec<f64> = zones
-            .iter()
-            .enumerate()
-            .map(|(i, zi)| (probed.get(zi).copied().unwrap_or(0.0) - bias0_vec[i]) / PROBE_W)
-            .collect();
-        if column[index_of[zone.as_str()]] < MIN_SELF_RESPONSE {
+        probe.scheduled_loads = scheduled_loads.to_vec();
+        probe.scheduled_w = fixed_w.clone(); // keep the fixed loads applied
+        probe.local_offset = local_offset;
+        let column = column_of(&probe);
+        if column.iter().fold(0.0_f64, |m, &c| m.max(c.abs())) < MIN_SELF_RESPONSE {
             eprintln!("  fit_gains: zone '{zone}' too weakly coupled to fit a gain, skipping");
             continue;
         }
-        cand.push(zone.clone());
+        gain_zones.push(zone.clone());
+        columns.push(column);
+    }
+    let n_gain_cands = gain_zones.len();
+
+    // One candidate per **fitted** scheduled load (`power_w` None) whose zone is in the model. A
+    // **fixed** load is a known input already applied in `fixed_w`, never a candidate. Probe by adding
+    // the unit magnitude to that load's slot (on top of the fixed magnitudes) and reading its coupled
+    // response.
+    let mut load_cand_idx: Vec<usize> = Vec::new(); // index into `scheduled_loads`
+    for (li, load) in scheduled_loads.iter().enumerate() {
+        if load.power_w.is_some() {
+            continue; // known magnitude — applied, not fitted
+        }
+        if !net.zone_indices.contains_key(&load.zone) {
+            continue;
+        }
+        let mut probe = data.clone();
+        probe.internal_gain_w = HashMap::new();
+        probe.scheduled_loads = scheduled_loads.to_vec();
+        let mut sched = fixed_w.clone();
+        sched[li] = PROBE_W;
+        probe.scheduled_w = sched;
+        probe.local_offset = local_offset;
+        let column = column_of(&probe);
+        if column.iter().fold(0.0_f64, |m, &c| m.max(c.abs())) < MIN_SELF_RESPONSE {
+            eprintln!(
+                "  fit_gains: scheduled load '{}' too weakly coupled, skipping",
+                load.label
+            );
+            continue;
+        }
+        load_cand_idx.push(li);
         columns.push(column);
     }
 
-    // Assemble response[i][j] (zones × candidates) from the per-candidate columns.
-    let response: Vec<Vec<f64>> = (0..zones.len())
+    // Solve min‖column·c − target‖² s.t. c ≥ 0 (NNLS). The matrix is rows × candidates.
+    let n_cands = columns.len();
+    let matrix: Vec<Vec<f64>> = (0..rows.len())
         .map(|i| columns.iter().map(|col| col[i]).collect())
         .collect();
-    // Solve min‖response·g − (−bias0)‖² s.t. g ≥ 0 (NNLS).
-    let target: Vec<f64> = bias0_vec.iter().map(|b| -b).collect();
-    let g = nnls(&response, &target, cand.len());
-    // Drop thermally-negligible (sub-watt) gains: they're fit noise, not a real internal source.
-    const MIN_GAIN_W: f64 = 1.0;
-    cand.into_iter()
-        .zip(g)
+    let coeffs = nnls(&matrix, &target, n_cands);
+
+    // Constant-gain coeffs (≥ MIN_GAIN_W) → gains; the unit_profile already carries the sink/source
+    // sign, so a scheduled load's coeff is the (non-negative) watts it moves.
+    let gains: HashMap<String, f64> = gain_zones
+        .into_iter()
+        .zip(coeffs.iter().take(n_gain_cands).copied())
         .filter(|(_, w)| *w >= MIN_GAIN_W)
-        .collect()
+        .collect();
+    // Start from the configured magnitudes (a fixed load keeps its `power_w`) and overwrite only the
+    // fitted slots with their solved coeff.
+    let mut scheduled_w = fixed_w.clone();
+    for (slot, &w) in load_cand_idx.iter().zip(coeffs.iter().skip(n_gain_cands)) {
+        // Drop a sub-watt magnitude as fit noise — the same `MIN_GAIN_W` floor the constant gains use,
+        // so a load the data doesn't actually support reports 0 rather than a spurious fraction of a W.
+        // (Fitted slots only; a fixed slot is never visited by this loop.)
+        scheduled_w[*slot] = if w >= MIN_GAIN_W { w } else { 0.0 };
+    }
+    GainFit { gains, scheduled_w }
 }
 
-/// Fit the per-zone internal gains (W) over a trailing window — the **live self-correction**. Same
-/// coupled fit as [`calibrate_internal_gains`] but returning only the gains, so the shadow loop can
-/// re-fit periodically and track changes in occupant behaviour (more/fewer people, appliance use)
-/// without any config or model edit. An empty result means the model needs no extra gain anywhere.
-#[allow(clippy::too_many_arguments)] // the model, heating, site, window and time bounds are all distinct
+/// Fit the per-zone internal gains (W) and scheduled-load magnitudes over a trailing window — the
+/// **live self-correction**. Same coupled fit as [`calibrate_internal_gains`] but returning only the
+/// fit, so the shadow loop can re-fit periodically and track changes in occupant behaviour (more/fewer
+/// people, appliance use) without any config or model edit. An empty result means the model needs no
+/// extra gain anywhere.
+#[allow(clippy::too_many_arguments)] // the model, heating, loads, site, window and time bounds are all distinct
 pub async fn fit_internal_gains(
     db: &SourceClients,
     net: &RcNetwork,
     ss: &StateSpace,
     heating: &HeatingConfig,
+    scheduled_loads: &[ScheduledLoad],
+    local_offset: FixedOffset,
     latitude: Angle,
     longitude: Angle,
     cfg: &BacktestConfig,
     start: &str,
     stop: &str,
-) -> Result<HashMap<String, f64>> {
-    let (data, x0, zone_series) = load_active(db, net, ss, heating, cfg, start, stop).await?;
+) -> Result<GainFit> {
+    let (data, x0, zone_series) = load_active(
+        db,
+        net,
+        ss,
+        heating,
+        scheduled_loads,
+        local_offset,
+        cfg,
+        start,
+        stop,
+    )
+    .await?;
     Ok(fit_gains(
         net,
         ss,
@@ -382,28 +537,44 @@ pub async fn fit_internal_gains(
         &x0,
         &data,
         &zone_series,
+        scheduled_loads,
         cfg.window_hours as usize,
+        local_offset,
     ))
 }
 
-/// Calibrate the per-zone internal gains (W) **and** report the heat model's accuracy before and
-/// after — the active backtest. Drives the model with the recorded per-zone heating relays plus the
-/// measured outside temperature and solar, scores each zone with no gains (`before`), fits the gains
-/// (see [`fit_gains`]), and re-scores with them (`after`). The first `start..` hours act as warm-up;
-/// the last `cfg.window_hours` are scored. Returns `(before, after, gains_w)`.
-#[allow(clippy::too_many_arguments)] // the model, heating, site, window and time bounds are all distinct
+/// Calibrate the per-zone internal gains (W) and scheduled-load magnitudes **and** report the heat
+/// model's accuracy before and after — the active backtest. Drives the model with the recorded
+/// per-zone heating relays plus the measured outside temperature and solar, scores each zone with no
+/// gains (`before`), fits the gains + loads (see [`fit_gains`]), and re-scores with them (`after`).
+/// The first `start..` hours act as warm-up; the last `cfg.window_hours` are scored. Returns
+/// `(before, after, fit)`.
+#[allow(clippy::too_many_arguments)] // the model, heating, loads, site, window and time bounds are all distinct
 pub async fn calibrate_internal_gains(
     db: &SourceClients,
     net: &RcNetwork,
     ss: &StateSpace,
     heating: &HeatingConfig,
+    scheduled_loads: &[ScheduledLoad],
+    local_offset: FixedOffset,
     latitude: Angle,
     longitude: Angle,
     cfg: &BacktestConfig,
     start: &str,
     stop: &str,
-) -> Result<(Vec<ZoneBacktest>, Vec<ZoneBacktest>, HashMap<String, f64>)> {
-    let (mut data, x0, zone_series) = load_active(db, net, ss, heating, cfg, start, stop).await?;
+) -> Result<(Vec<ZoneBacktest>, Vec<ZoneBacktest>, GainFit)> {
+    let (mut data, x0, zone_series) = load_active(
+        db,
+        net,
+        ss,
+        heating,
+        scheduled_loads,
+        local_offset,
+        cfg,
+        start,
+        stop,
+    )
+    .await?;
     let window = cfg.window_hours as usize;
     let before = score_zones(
         net,
@@ -413,7 +584,7 @@ pub async fn calibrate_internal_gains(
         &zone_series,
         window,
     );
-    let gains = fit_gains(
+    let fit = fit_gains(
         net,
         ss,
         latitude,
@@ -421,9 +592,12 @@ pub async fn calibrate_internal_gains(
         &x0,
         &data,
         &zone_series,
+        scheduled_loads,
         window,
+        local_offset,
     );
-    data.internal_gain_w = gains.clone();
+    data.internal_gain_w = fit.gains.clone();
+    data.scheduled_w = fit.scheduled_w.clone();
     let after = score_zones(
         net,
         ss,
@@ -432,7 +606,7 @@ pub async fn calibrate_internal_gains(
         &zone_series,
         window,
     );
-    Ok((before, after, gains))
+    Ok((before, after, fit))
 }
 
 #[cfg(test)]
@@ -525,5 +699,305 @@ mod tests {
         let a = vec![vec![], vec![], vec![]];
         let b = vec![1.0, 2.0, 3.0];
         assert!(nnls(&a, &b, 0).is_empty());
+    }
+
+    use crate::model::Model;
+    use crate::optimize::config::{LoadKind, LoadWindow};
+    use uom::si::angle::degree;
+    use uom::si::f64::ThermodynamicTemperature;
+    use uom::si::thermodynamic_temperature::degree_celsius;
+
+    /// A tiny single-zone house: a floor to ground and a wall to outside. Enough thermal mass that the
+    /// air node responds to a sustained air-node flux but doesn't track it instantly.
+    fn one_zone() -> (RcNetwork, StateSpace) {
+        let model = Model::from_json(
+            r#"{
+                materials: {
+                    air: { thermal_conductivity: 0.026, specific_heat_capacity: 1000, density: 1.2 },
+                    concrete: { thermal_conductivity: 1.5, specific_heat_capacity: 1000, density: 2000 },
+                    insulation: { thermal_conductivity: 0.04, specific_heat_capacity: 1000, density: 30 },
+                },
+                boundary_types: {
+                    floor: { layers: [ { material: "concrete", thickness: 0.1 } ] },
+                    wall: { layers: [
+                        { material: "concrete", thickness: 0.1 },
+                        { material: "insulation", thickness: 0.12 },
+                    ] },
+                },
+                zones: { lr: { volume: 40 } },
+                boundaries: [
+                    { boundary_type: "floor", zones: ["lr", "ground"], area: 16 },
+                    { boundary_type: "wall",  zones: ["lr", "outside"], area: 30 },
+                ],
+            }"#,
+        )
+        .unwrap();
+        let net: RcNetwork = (&model).into();
+        let ss: StateSpace = (&net).into();
+        (net, ss)
+    }
+
+    /// A hand-built `DriveData` over `n_hours` from `start_hour` (unix-hour), constant outside temp,
+    /// no cloud, no heating, carrying the given scheduled loads at zero magnitude and the offset.
+    fn synthetic_drive(
+        start_hour: i64,
+        n_hours: usize,
+        outside_c: f64,
+        loads: &[ScheduledLoad],
+        local_offset: FixedOffset,
+    ) -> DriveData {
+        let hours: Vec<i64> = (start_hour..start_hour + n_hours as i64).collect();
+        let grid_times = hours
+            .iter()
+            .map(|h| Utc.timestamp_opt(h * 3600, 0).single().unwrap())
+            .collect();
+        DriveData {
+            grid_times,
+            hours,
+            outside_c: vec![outside_c; n_hours],
+            cloud: vec![1.0; n_hours], // fully overcast → solar gain negligible, keeps the test simple
+            ground_c: 12.0,
+            heating_kw: HashMap::new(),
+            internal_gain_w: HashMap::new(),
+            scheduled_loads: loads.to_vec(),
+            scheduled_w: vec![0.0; loads.len()],
+            local_offset,
+        }
+    }
+
+    /// KEYSTONE: the fit recovers a known scheduled-sink magnitude from a self-generated "measured"
+    /// trajectory, and attributes the windowed sink to the scheduled load — not to a constant gain.
+    /// This is the correctness gate: a flat gain and a time-localized load are collinear against a
+    /// single window mean; the trajectory fit separates them.
+    #[test]
+    fn fit_recovers_scheduled_sink_magnitude() {
+        let (net, ss) = one_zone();
+        let local_offset = FixedOffset::east_opt(0).unwrap(); // UTC == local: window hours are unix hours
+        let (lat, lon) = (Angle::new::<degree>(50.0), Angle::new::<degree>(14.0));
+
+        // A daytime sink in `lr`, active 10:00–14:00 every day. Start the grid at unix-hour 0 (a
+        // midnight) and run five days so the on/off shape repeats and the slab seed washes out.
+        let load = ScheduledLoad {
+            zone: "lr".to_string(),
+            label: "water heat-pump".to_string(),
+            kind: LoadKind::Sink,
+            power_w: None,
+            windows: vec![LoadWindow {
+                months: Vec::new(),
+                start: "10:00".to_string(),
+                end: "14:00".to_string(),
+            }],
+        };
+        let loads = [load];
+        let n_hours = 24 * 5;
+        let mut data = synthetic_drive(0, n_hours, 8.0, &loads, local_offset);
+
+        // Seed the state at a uniform 20 °C.
+        let x0 = DVector::from_element(
+            ss.n_states(),
+            ThermodynamicTemperature::new::<degree_celsius>(20.0)
+                .get::<uom::si::thermodynamic_temperature::kelvin>(),
+        );
+
+        // Generate the "measured" series by driving WITH the true sink magnitude.
+        const TRUE_W: f64 = 800.0;
+        let mut truth = data.clone();
+        truth.scheduled_w = vec![TRUE_W];
+        let truth_traj = drive(&net, &ss, lat, lon, &x0, &truth);
+        let state_row = ss.state_index(net.zone_indices["lr"]).unwrap();
+        let zone_series: HashMap<String, Vec<TimeSample>> = HashMap::from([(
+            "lr".to_string(),
+            data.hours
+                .iter()
+                .zip(&truth_traj)
+                .map(|(&h, x)| TimeSample {
+                    time: Utc.timestamp_opt(h * 3600, 0).single().unwrap(),
+                    value: k_to_c(x[state_row]),
+                })
+                .collect(),
+        )]);
+
+        // `data` carries the loads at zero magnitude (as load_active would); fit over the full window.
+        data.scheduled_w = vec![0.0];
+        let fit = fit_gains(
+            &net,
+            &ss,
+            lat,
+            lon,
+            &x0,
+            &data,
+            &zone_series,
+            &loads,
+            n_hours,
+            local_offset,
+        );
+
+        // (a) the sink magnitude is recovered within a few percent.
+        let recovered = fit.scheduled_w[0];
+        let rel_err = (recovered - TRUE_W).abs() / TRUE_W;
+        assert!(
+            rel_err < 0.05,
+            "recovered sink {recovered:.1} W vs true {TRUE_W} W (rel err {:.3})",
+            rel_err
+        );
+        // (b) the constant gain for the zone stays near 0 — the windowed sink is attributed to the
+        // scheduled load, not absorbed by an always-on gain. (Cooling can't be a gain at all — gains
+        // are ≥ 0 — so the real risk is the fit assigning a spurious *positive* gain; assert it's tiny.)
+        let gain = fit.gains.get("lr").copied().unwrap_or(0.0);
+        assert!(
+            gain < 0.05 * TRUE_W,
+            "constant gain {gain:.1} W should be ~0"
+        );
+    }
+
+    /// The central claim, the hard case: a zone with BOTH an always-on internal gain AND a windowed
+    /// sink. A single window mean couldn't separate them (collinear); the trajectory fit must recover
+    /// *both*. Generate "measured" with both, fit with both unknown, assert each is recovered.
+    #[test]
+    fn fit_separates_constant_gain_from_scheduled_sink() {
+        let (net, ss) = one_zone();
+        let local_offset = FixedOffset::east_opt(0).unwrap();
+        let (lat, lon) = (Angle::new::<degree>(50.0), Angle::new::<degree>(14.0));
+        let loads = [ScheduledLoad {
+            zone: "lr".to_string(),
+            label: "water heat-pump".to_string(),
+            kind: LoadKind::Sink,
+            power_w: None,
+            windows: vec![LoadWindow {
+                months: Vec::new(),
+                start: "10:00".to_string(),
+                end: "14:00".to_string(),
+            }],
+        }];
+        let n_hours = 24 * 5;
+        let mut data = synthetic_drive(0, n_hours, 8.0, &loads, local_offset);
+        let x0 = DVector::from_element(
+            ss.n_states(),
+            ThermodynamicTemperature::new::<degree_celsius>(20.0)
+                .get::<uom::si::thermodynamic_temperature::kelvin>(),
+        );
+
+        // Truth: a 200 W always-on gain AND an 800 W daytime sink, both in `lr` (net warming, so the
+        // zone still reads "cold" against the no-gain baseline and gets an internal-gain candidate).
+        const TRUE_GAIN: f64 = 200.0;
+        const TRUE_SINK: f64 = 800.0;
+        let mut truth = data.clone();
+        truth.internal_gain_w = HashMap::from([("lr".to_string(), TRUE_GAIN)]);
+        truth.scheduled_w = vec![TRUE_SINK];
+        let truth_traj = drive(&net, &ss, lat, lon, &x0, &truth);
+        let state_row = ss.state_index(net.zone_indices["lr"]).unwrap();
+        let zone_series: HashMap<String, Vec<TimeSample>> = HashMap::from([(
+            "lr".to_string(),
+            data.hours
+                .iter()
+                .zip(&truth_traj)
+                .map(|(&h, x)| TimeSample {
+                    time: Utc.timestamp_opt(h * 3600, 0).single().unwrap(),
+                    value: k_to_c(x[state_row]),
+                })
+                .collect(),
+        )]);
+
+        data.scheduled_w = vec![0.0];
+        let fit = fit_gains(
+            &net,
+            &ss,
+            lat,
+            lon,
+            &x0,
+            &data,
+            &zone_series,
+            &loads,
+            n_hours,
+            local_offset,
+        );
+
+        let gain = fit.gains.get("lr").copied().unwrap_or(0.0);
+        let sink = fit.scheduled_w[0];
+        let gain_err = (gain - TRUE_GAIN).abs() / TRUE_GAIN;
+        let sink_err = (sink - TRUE_SINK).abs() / TRUE_SINK;
+        assert!(
+            gain_err < 0.1 && sink_err < 0.1,
+            "recovered gain {gain:.1} W (true {TRUE_GAIN}), sink {sink:.1} W (true {TRUE_SINK})"
+        );
+    }
+
+    /// A **fixed-magnitude** load (`power_w` set) is a known input: it's applied as-is and the fit must
+    /// not change it. The harder claim: in a zone with a fixed sink AND an unknown constant gain, the
+    /// gain is recovered while the fixed sink stays at exactly its configured value.
+    #[test]
+    fn fit_keeps_fixed_load_and_recovers_gain_alongside() {
+        let (net, ss) = one_zone();
+        let local_offset = FixedOffset::east_opt(0).unwrap();
+        let (lat, lon) = (Angle::new::<degree>(50.0), Angle::new::<degree>(14.0));
+
+        const FIXED_SINK: f64 = 800.0;
+        const TRUE_GAIN: f64 = 200.0;
+
+        // The same windowed sink as the other tests, but with its magnitude CONFIGURED (`power_w`).
+        let loads = [ScheduledLoad {
+            zone: "lr".to_string(),
+            label: "water heat-pump".to_string(),
+            kind: LoadKind::Sink,
+            power_w: Some(FIXED_SINK),
+            windows: vec![LoadWindow {
+                months: Vec::new(),
+                start: "10:00".to_string(),
+                end: "14:00".to_string(),
+            }],
+        }];
+        let n_hours = 24 * 5;
+        let data = synthetic_drive(0, n_hours, 8.0, &loads, local_offset);
+        let x0 = DVector::from_element(
+            ss.n_states(),
+            ThermodynamicTemperature::new::<degree_celsius>(20.0)
+                .get::<uom::si::thermodynamic_temperature::kelvin>(),
+        );
+
+        // Truth: the fixed 800 W daytime sink AND a 200 W always-on gain, both in `lr`.
+        let mut truth = data.clone();
+        truth.internal_gain_w = HashMap::from([("lr".to_string(), TRUE_GAIN)]);
+        truth.scheduled_w = vec![FIXED_SINK];
+        let truth_traj = drive(&net, &ss, lat, lon, &x0, &truth);
+        let state_row = ss.state_index(net.zone_indices["lr"]).unwrap();
+        let zone_series: HashMap<String, Vec<TimeSample>> = HashMap::from([(
+            "lr".to_string(),
+            data.hours
+                .iter()
+                .zip(&truth_traj)
+                .map(|(&h, x)| TimeSample {
+                    time: Utc.timestamp_opt(h * 3600, 0).single().unwrap(),
+                    value: k_to_c(x[state_row]),
+                })
+                .collect(),
+        )]);
+
+        // The fit is handed the loads with the fixed magnitude; `data.scheduled_w` is irrelevant for a
+        // fixed slot (the fit reads `power_w` and applies it itself).
+        let fit = fit_gains(
+            &net,
+            &ss,
+            lat,
+            lon,
+            &x0,
+            &data,
+            &zone_series,
+            &loads,
+            n_hours,
+            local_offset,
+        );
+
+        // (a) the fixed sink is applied as-is and the fit does NOT change it — exactly the config value.
+        assert_eq!(
+            fit.scheduled_w[0], FIXED_SINK,
+            "a fixed load must keep its configured magnitude"
+        );
+        // (b) the constant gain is recovered alongside it.
+        let gain = fit.gains.get("lr").copied().unwrap_or(0.0);
+        let gain_err = (gain - TRUE_GAIN).abs() / TRUE_GAIN;
+        assert!(
+            gain_err < 0.1,
+            "recovered gain {gain:.1} W (true {TRUE_GAIN}) with the fixed sink held"
+        );
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -509,12 +509,16 @@ async fn get_thermal_backtest(
             .clone()
             .unwrap_or_else(|| format!("-{}h", warmup + window));
         let stop = p.stop.clone().unwrap_or_else(|| "now()".to_string());
+        let local_offset = chrono::FixedOffset::east_opt(s.config.site.utc_offset_hours * 3600)
+            .expect("site.utc_offset_hours validated at config load");
         cached(&s, key, || async {
-            let (before, after, gains_w) = calibrate_internal_gains(
+            let (before, after, fit) = calibrate_internal_gains(
                 &s.db,
                 &s.net,
                 &s.ss,
                 &s.config.heating,
+                &s.config.scheduled_loads,
+                local_offset,
                 s.latitude,
                 s.longitude,
                 &cfg,
@@ -522,10 +526,12 @@ async fn get_thermal_backtest(
                 &stop,
             )
             .await?;
+            // Scheduled-load magnitudes aren't surfaced here (dashboard display is a follow-up); the
+            // backtest reports only the per-zone internal gains, unchanged.
             Ok(ActiveBacktest {
                 before,
                 after,
-                gains_w,
+                gains_w: fit.gains,
             })
         })
         .await


### PR DESCRIPTION
Adds **scheduled loads** — known appliances the physics model has no source for, modelled as auto-fitted heat fluxes.

A scheduled load (e.g. a water heat-pump that cools its room, or a fireplace) is configured with only a **direction** (`sink`/`source`) and a **schedule** (local-time windows, optionally per-month). The thermal **calibration learns its magnitude** (W) from data; the model then applies `magnitude × unit_profile(local time)` as a flux at the zone's air node — in BOTH the optimizer prediction and the calibration drive, so the live internal-gain fit never double-counts it.

### Why the fit changed
To learn the magnitude, the calibration must separate the scheduled load from a zone's constant internal gain. Against a single window-mean they're collinear, so `fit_gains` was reworked from a window-mean bias to a **per-(zone, hour) residual trajectory** fit — a flat gain and a time-windowed load have different shapes and separate cleanly (NNLS). Returns `GainFit { gains, scheduled_w }`.

### Tests
- `fit_recovers_scheduled_sink_magnitude` — round-trips a known 800 W sink (recovered exactly; no spurious gain).
- `fit_separates_constant_gain_from_scheduled_sink` — a zone with **both** a 200 W gain and an 800 W sink; recovers both within 10%.

### Notes
- The MPC binary stays **structurally read-only** (no MQTT dep; CI-enforced).
- Config example + sink/source convention documented in `docs/configuration.md`.
- Dashboard display of the fitted magnitudes is a deliberate follow-up (not in this PR).
- Reviewed via the repo's iterative multi-agent review (5 agents). **Opened for review — not for merge yet.**