### PR TITLE
Scheduled loads: measured-draw sensor + controllable load-shifting scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,6 +1079,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpc-controller-boiler"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "controller_common",
+ "controller_protocol",
+ "json5",
+ "rumqttc",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "mpc-controller-ev"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "controllers/growatt",
     "controllers/heating",
     "controllers/ev",
+    "controllers/boiler",
     "adapters/mqtt-common",
     "adapters/mqtt-bridge",
     "adapters/mqtt-source",

--- a/controllers/boiler/Cargo.toml
+++ b/controllers/boiler/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mpc-controller-boiler"
+version = "0.1.0"
+edition = "2021"
+description = "Controller: translates the MPC's controllable-load (boiler / hot-water tank) plan into a device command (stub — logged would-send only, no real protocol yet; dry-run draft)."
+
+[[bin]]
+name = "mpc-controller-boiler"
+path = "src/main.rs"
+
+[dependencies]
+controller_protocol = { workspace = true }
+controller_common = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+anyhow = { workspace = true }
+json5 = { workspace = true }
+rumqttc = { workspace = true }
+tokio = { workspace = true }

--- a/controllers/boiler/boiler.example.json5
+++ b/controllers/boiler/boiler.example.json5
@@ -1,0 +1,29 @@
+// mpc-controller-boiler — example configuration.
+//
+// Subscribes the inert north command topic (mpc/control/boiler) the publisher republishes the MPC's
+// controllable-load (boiler / hot-water tank) plan to, and translates each load's first-block on/off
+// decision into a device command.
+//
+// STUB: the real boiler hardware (a Modbus relay / smart socket) isn't wired yet, so this controller
+// only *logs* the would-send record — it never drives any device, even with `armed: true`. When the
+// Modbus boiler arrives, the translate path grows the real datagram; the scaffold around it (subscribe,
+// deadman, dry-run, failsafe) stays as-is.
+{
+  armed: false,
+
+  mqtt: {
+    host: "127.0.0.1",
+    port: 1883,
+    client_id: "mpc-controller-boiler",
+  },
+
+  controller_id: "boiler",
+  control_topic: "mpc/control/boiler",
+
+  // A label for the not-yet-wired device target, recorded in the would-send audit log.
+  target_label: "boiler-modbus",
+
+  // On deadman expiry (a stale plan): "hold" lets the existing boiler control resume; "all_off"
+  // drives every load off first.
+  failsafe: "hold",
+}

--- a/controllers/boiler/src/config.rs
+++ b/controllers/boiler/src/config.rs
@@ -1,0 +1,116 @@
+//! Boiler controller configuration (JSON5).
+
+use anyhow::Result;
+use serde::Deserialize;
+use std::path::Path;
+
+use crate::translate::TranslateCfg;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BoilerControllerConfig {
+    /// Intends to actuate; a real send would also require the `MPC_CONTROLLER_ARM` env token. Default
+    /// dry-run. (The translate path is a stub today, so even armed it only logs — see `translate.rs`.)
+    #[serde(default)]
+    pub armed: bool,
+    #[serde(default)]
+    pub mqtt: MqttConfig,
+    #[serde(default = "default_controller_id")]
+    pub controller_id: String,
+    /// North topic this controller subscribes to for commands.
+    #[serde(default = "default_control_topic")]
+    pub control_topic: String,
+    /// A label for the (not-yet-wired) device target, recorded in the would-send audit log.
+    #[serde(default = "default_target_label")]
+    pub target_label: String,
+    /// On deadman expiry: `hold` (stop sending — the existing system resumes) or `all_off` (drive all
+    /// loads off).
+    #[serde(default = "default_failsafe")]
+    pub failsafe: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MqttConfig {
+    #[serde(default = "controller_common::default_mqtt_host")]
+    pub host: String,
+    #[serde(default = "controller_common::default_mqtt_port")]
+    pub port: u16,
+    #[serde(default = "default_client_id")]
+    pub client_id: String,
+}
+
+impl Default for MqttConfig {
+    fn default() -> Self {
+        Self {
+            host: controller_common::default_mqtt_host(),
+            port: controller_common::default_mqtt_port(),
+            client_id: default_client_id(),
+        }
+    }
+}
+
+impl BoilerControllerConfig {
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let cfg: Self = json5::from_str(&std::fs::read_to_string(path)?)?;
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    /// Reject a config that would silently misbehave at runtime. `failsafe` is compared `== "all_off"`
+    /// with every other value falling through to *hold*, so a typo would silently get `hold` — pin it
+    /// to the known set at load. (Mirrors the EV controller.)
+    fn validate(&self) -> Result<()> {
+        anyhow::ensure!(
+            matches!(self.failsafe.as_str(), "hold" | "all_off"),
+            "failsafe must be \"hold\" or \"all_off\", got {:?}",
+            self.failsafe
+        );
+        Ok(())
+    }
+
+    pub fn translate_cfg(&self) -> TranslateCfg {
+        TranslateCfg {
+            target_label: self.target_label.clone(),
+        }
+    }
+}
+
+fn default_controller_id() -> String {
+    "boiler".to_string()
+}
+fn default_control_topic() -> String {
+    "mpc/control/boiler".to_string()
+}
+fn default_target_label() -> String {
+    "boiler".to_string()
+}
+fn default_failsafe() -> String {
+    "hold".to_string()
+}
+fn default_client_id() -> String {
+    "mpc-controller-boiler".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_with_failsafe(failsafe: &str) -> BoilerControllerConfig {
+        json5::from_str(&format!(r#"{{ failsafe: "{failsafe}" }}"#)).unwrap()
+    }
+
+    #[test]
+    fn failsafe_must_be_a_known_mode() {
+        assert!(cfg_with_failsafe("hold").validate().is_ok());
+        assert!(cfg_with_failsafe("all_off").validate().is_ok());
+        assert!(cfg_with_failsafe("all-off").validate().is_err());
+    }
+
+    #[test]
+    fn defaults_are_sane() {
+        let cfg: BoilerControllerConfig = json5::from_str("{}").unwrap();
+        assert_eq!(cfg.controller_id, "boiler");
+        assert_eq!(cfg.control_topic, "mpc/control/boiler");
+        assert!(!cfg.armed);
+        assert!(cfg.validate().is_ok());
+    }
+}

--- a/controllers/boiler/src/main.rs
+++ b/controllers/boiler/src/main.rs
@@ -1,0 +1,241 @@
+//! `mpc-controller-boiler` — the controllable-load (boiler / hot-water tank) path: the MPC's
+//! per-load on/off plan becomes a device command.
+//!
+//! **Stub / dry-run draft.** Subscribes the north command topic, translates the `Payload::Load`
+//! channels into a logged would-send record ([`translate`]), and prints it. No real device protocol
+//! is wired yet (the Modbus boiler hasn't arrived), so it never actuates — even the `armed` path only
+//! logs, until [`translate`] grows a real datagram. A `valid_until` deadman either holds (the existing
+//! system resumes) or drives all loads off. The publisher only sends channels for configured
+//! controllable loads, so nothing else reaches here.
+
+mod config;
+mod translate;
+
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use controller_protocol::{
+    actions_changed, topics, ControlCommand, ControllerStatus, LoadChannel, Mode, Payload,
+    PlannedAction, SCHEMA_VERSION,
+};
+use rumqttc::{AsyncClient, Event, Incoming, LastWill, MqttOptions, QoS};
+
+use crate::config::BoilerControllerConfig;
+use crate::translate::{translate, TranslateCfg};
+
+/// The exact env token that *would* be required (alongside `armed: true`) before any real send. The
+/// translate path is a stub today, so this only governs the would-be-armed annotation in the log.
+const ARM_TOKEN: &str = "i-understand-this-actuates";
+
+fn resolve_armed(cfg: &BoilerControllerConfig) -> bool {
+    cfg.armed && std::env::var("MPC_CONTROLLER_ARM").as_deref() == Ok(ARM_TOKEN)
+}
+
+struct State {
+    cfg: BoilerControllerConfig,
+    tcfg: TranslateCfg,
+    client: AsyncClient,
+    armed: bool,
+    last_seq: Option<u64>,
+    last_actions: Vec<PlannedAction>,
+    last_channels: Vec<LoadChannel>,
+    last_command_at: Option<DateTime<Utc>>,
+    reverted: bool,
+    valid_until: Option<DateTime<Utc>>,
+    /// Monotonic deadline for the deadman — immune to wall-clock steps.
+    deadman_at: Option<Instant>,
+}
+
+impl State {
+    async fn on_command(&mut self, bytes: &[u8]) {
+        let cmd: ControlCommand = match serde_json::from_slice(bytes) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("[boiler] ignoring malformed command JSON: {e}");
+                return;
+            }
+        };
+        if let Err(why) = cmd.accept(&self.cfg.controller_id, self.last_seq, Utc::now()) {
+            println!("[boiler] ignoring command: {why}");
+            return;
+        }
+        let Payload::Load { channels } = &cmd.payload else {
+            println!("[boiler] ignoring non-load payload");
+            return;
+        };
+
+        self.last_seq = Some(cmd.command_seq);
+        self.last_command_at = Some(Utc::now());
+        self.valid_until = Some(cmd.valid_until);
+        self.deadman_at = Some(controller_common::monotonic_deadline(cmd.valid_until));
+        self.reverted = false;
+        self.last_channels = channels.clone();
+
+        let actions: Vec<PlannedAction> = translate(channels, &self.tcfg).into_iter().collect();
+        if !actions_changed(&self.last_actions, &actions) {
+            println!(
+                "[boiler] command seq {} unchanged — skipping re-log",
+                cmd.command_seq
+            );
+            return;
+        }
+        let ctx = format!("command seq {}", cmd.command_seq);
+        self.apply(actions, &ctx).await;
+    }
+
+    async fn apply(&mut self, actions: Vec<PlannedAction>, ctx: &str) {
+        println!(
+            "[boiler] {ctx} — {} record(s) [{}, stub: no device protocol yet]:",
+            actions.len(),
+            if self.armed { "would-arm" } else { "dry-run" }
+        );
+        for act in &actions {
+            // The stub never sends, so `published` stays false in both modes.
+            println!(
+                "    would-send {} {}  ({})",
+                act.target, act.message, act.reason
+            );
+        }
+        self.last_actions = actions.clone();
+        self.publish_status(actions).await;
+    }
+
+    async fn check_deadman(&mut self) {
+        if self.reverted {
+            return;
+        }
+        let Some(deadman) = self.deadman_at else {
+            return;
+        };
+        if Instant::now() < deadman {
+            return;
+        }
+        self.reverted = true;
+        println!(
+            "[boiler] DEADMAN expired (valid_until {:?}) → failsafe '{}'",
+            self.valid_until, self.cfg.failsafe
+        );
+        if self.cfg.failsafe == "all_off" {
+            // Drive every last-known load off; the existing system takes over from there.
+            let off: Vec<LoadChannel> = self
+                .last_channels
+                .iter()
+                .map(|c| LoadChannel {
+                    channel: c.channel.clone(),
+                    power_kw: 0.0,
+                    enabled: false,
+                    target_c: None,
+                    target_soc: c.target_soc,
+                })
+                .collect();
+            let actions: Vec<PlannedAction> = translate(&off, &self.tcfg).into_iter().collect();
+            self.apply(actions, "failsafe all_off").await;
+        }
+        // "hold" → log nothing; the existing boiler control resumes.
+    }
+
+    async fn publish_status(&self, actions: Vec<PlannedAction>) {
+        let status = ControllerStatus {
+            schema_version: SCHEMA_VERSION.to_string(),
+            controller_id: self.cfg.controller_id.clone(),
+            at: Utc::now(),
+            mode: if self.armed {
+                Mode::Armed
+            } else {
+                Mode::DryRun
+            },
+            last_command_at: self.last_command_at,
+            deadman_expired: self.reverted,
+            telemetry: serde_json::Value::Null, // the boiler isn't read back on this stub path
+            actions,
+        };
+        if let Ok(json) = serde_json::to_string(&status) {
+            let _ = self
+                .client
+                .publish(
+                    topics::status(&self.cfg.controller_id),
+                    QoS::AtLeastOnce,
+                    false,
+                    json.into_bytes(),
+                )
+                .await;
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "boiler.json5".to_string());
+    let cfg = BoilerControllerConfig::load(&path)?;
+    let armed = resolve_armed(&cfg);
+    println!(
+        "--- mpc-controller-boiler {} — STUB: logging would-send records only, no device is driven ---",
+        if armed { "(config armed)" } else { "DRY-RUN" }
+    );
+
+    let mut opts = MqttOptions::new(&cfg.mqtt.client_id, &cfg.mqtt.host, cfg.mqtt.port);
+    opts.set_keep_alive(Duration::from_secs(30));
+    let health = topics::health(&cfg.controller_id);
+    opts.set_last_will(LastWill::new(
+        health.clone(),
+        "offline",
+        QoS::AtLeastOnce,
+        true,
+    ));
+    let (client, mut eventloop) = AsyncClient::new(opts, 64);
+    client
+        .subscribe(&cfg.control_topic, QoS::AtLeastOnce)
+        .await?;
+    client
+        .publish(health, QoS::AtLeastOnce, true, "online")
+        .await?;
+
+    let control_topic = cfg.control_topic.clone();
+    println!("[boiler] listening on {control_topic} (stub)");
+    let tcfg = cfg.translate_cfg();
+    let mut state = State {
+        cfg,
+        tcfg,
+        client,
+        armed,
+        last_seq: None,
+        last_actions: Vec::new(),
+        last_channels: Vec::new(),
+        last_command_at: None,
+        reverted: false,
+        valid_until: None,
+        deadman_at: None,
+    };
+
+    let mut deadman = tokio::time::interval(Duration::from_secs(5));
+    loop {
+        tokio::select! {
+            ev = eventloop.poll() => match ev {
+                // rumqttc doesn't replay subscriptions after a reconnect — re-subscribe on every ConnAck.
+                Ok(Event::Incoming(Incoming::ConnAck(_))) => {
+                    let id = state.cfg.controller_id.clone();
+                    let _ = state.client.subscribe(&control_topic, QoS::AtLeastOnce).await;
+                    let _ = state
+                        .client
+                        .publish(topics::health(&id), QoS::AtLeastOnce, true, "online")
+                        .await;
+                    println!("[boiler] (re)connected, subscribed to {control_topic}");
+                }
+                Ok(Event::Incoming(Incoming::Publish(p))) => {
+                    if p.topic == control_topic {
+                        state.on_command(&p.payload).await;
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    eprintln!("[boiler] mqtt connection: {e}");
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                }
+            },
+            _ = deadman.tick() => state.check_deadman().await,
+        }
+    }
+}

--- a/controllers/boiler/src/translate.rs
+++ b/controllers/boiler/src/translate.rs
@@ -1,0 +1,127 @@
+//! The pure translation from a protocol [`Payload::Load`](controller_protocol::Payload::Load) into a
+//! device command — IO-free and unit-tested.
+//!
+//! **Stub.** The real boiler hardware (a Modbus relay / smart socket) isn't wired yet, so this does
+//! not speak any device protocol. It produces a single logged **would-send** [`PlannedAction`] that
+//! records the per-channel on/off setpoint the controller *would* drive — the audit record the
+//! runtime prints in dry-run. When the Modbus boiler arrives, replace the `target`/`message` here
+//! with the real datagram (the controller scaffold around it stays the same).
+
+use controller_protocol::{LoadChannel, PlannedAction};
+
+/// Settings for building the (stub) command.
+#[derive(Debug, Clone)]
+pub struct TranslateCfg {
+    /// A label for the device target in the would-send record (e.g. `"boiler-modbus"`). No real
+    /// endpoint is contacted yet — it only annotates the audit log.
+    pub target_label: String,
+}
+
+/// Round a kW power to 3 decimals (→ W resolution) for a stable, noise-free record. A non-finite
+/// input (which the plan should never produce) is coerced to 0.
+fn round3(value: f64) -> f64 {
+    if value.is_finite() {
+        (value * 1000.0).round() / 1000.0
+    } else {
+        0.0
+    }
+}
+
+/// Build the single (stub) would-send action for all controllable-load channels — keys sorted for a
+/// deterministic record, joined by `;`. Returns `None` when there are no valid channels (the list is
+/// empty, or every name was dropped as malformed). **No hardware is touched**; `published` stays
+/// `false` and the runtime only logs it.
+pub fn translate(channels: &[LoadChannel], cfg: &TranslateCfg) -> Option<PlannedAction> {
+    if channels.is_empty() {
+        return None;
+    }
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    let mut on_count = 0usize;
+    for ch in channels {
+        // Skip a channel name that would corrupt the `key=value;…` record.
+        if ch.channel.is_empty() || ch.channel.contains([';', '=', '\n', '\r']) {
+            continue;
+        }
+        if ch.enabled {
+            on_count += 1;
+        }
+        pairs.push((
+            format!("{}_kw", ch.channel),
+            format!("{}", round3(ch.power_kw)),
+        ));
+        pairs.push((
+            format!("{}_on", ch.channel),
+            u8::from(ch.enabled).to_string(),
+        ));
+    }
+    if pairs.is_empty() {
+        return None;
+    }
+    pairs.sort();
+    let n_channels = pairs.iter().filter(|(k, _)| k.ends_with("_on")).count();
+    let message = pairs
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(";");
+    Some(PlannedAction {
+        target: format!("stub://{}", cfg.target_label),
+        message,
+        published: false, // stub: nothing is ever actually sent
+        reason: format!("{on_count}/{n_channels} load(s) on (stub — no device protocol yet)"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> TranslateCfg {
+        TranslateCfg {
+            target_label: "boiler-modbus".to_string(),
+        }
+    }
+
+    fn ch(name: &str, power: f64, on: bool) -> LoadChannel {
+        LoadChannel {
+            channel: name.to_string(),
+            power_kw: power,
+            enabled: on,
+            target_c: None,
+            target_soc: None,
+        }
+    }
+
+    #[test]
+    fn builds_sorted_stub_record_with_power_and_on() {
+        let a = translate(&[ch("boiler", 2.0, true)], &cfg()).unwrap();
+        assert_eq!(a.target, "stub://boiler-modbus");
+        // sorted: _kw before _on
+        assert_eq!(a.message, "boiler_kw=2;boiler_on=1");
+        assert_eq!(a.reason, "1/1 load(s) on (stub — no device protocol yet)");
+        assert!(!a.published, "the stub never actually sends");
+    }
+
+    #[test]
+    fn off_load_emits_zero() {
+        let a = translate(&[ch("boiler", 0.0, false)], &cfg()).unwrap();
+        assert_eq!(a.message, "boiler_kw=0;boiler_on=0");
+        assert_eq!(a.reason, "0/1 load(s) on (stub — no device protocol yet)");
+    }
+
+    #[test]
+    fn no_channels_is_none() {
+        assert!(translate(&[], &cfg()).is_none());
+    }
+
+    #[test]
+    fn malformed_channel_names_are_dropped() {
+        let a = translate(
+            &[ch("k;evil=1", 1.0, true), ch("boiler", 2.0, true)],
+            &cfg(),
+        )
+        .unwrap();
+        assert_eq!(a.message, "boiler_kw=2;boiler_on=1");
+        assert!(translate(&[ch("k;evil=1", 1.0, true)], &cfg()).is_none());
+    }
+}

--- a/controllers/publisher/src/build.rs
+++ b/controllers/publisher/src/build.rs
@@ -106,13 +106,35 @@ pub fn commands(
         ));
     }
 
+    if let Some(b) = &cfg.boiler {
+        // One channel per controllable load, with the coming block's planned draw as the setpoint and
+        // an `enabled` flag from the on-threshold (the load-shift on/off decision). A generic
+        // `Payload::Load`, like the EV path — the boiler controller reads it.
+        let mut channels: Vec<LoadChannel> = fs
+            .controllable_load_kw
+            .iter()
+            .map(|(name, &power_kw)| LoadChannel {
+                channel: name.clone(),
+                power_kw,
+                enabled: power_kw > b.on_threshold_kw,
+                target_c: None,
+                target_soc: None,
+            })
+            .collect();
+        channels.sort_by(|a, b| a.channel.cmp(&b.channel)); // deterministic order
+        out.push((
+            b.controller_id.clone(),
+            envelope(&b.controller_id, Payload::Load { channels }),
+        ));
+    }
+
     out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{BatteryPub, EvPub, HeatingPub, MqttConfig, PublisherConfig};
+    use crate::config::{BatteryPub, BoilerPub, EvPub, HeatingPub, MqttConfig, PublisherConfig};
 
     fn utc(s: &str) -> DateTime<Utc> {
         DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
@@ -129,6 +151,7 @@ mod tests {
                     "hour_start": "2026-06-23T12:00:00Z",
                     "heat_kw": { "livingroom": 2.4, "office": 0.0 },
                     "cool_kw": {},
+                    "controllable_load_kw": { "water heat-pump": 2.0 },
                     "battery_charge_kw": 3.0,
                     "battery_discharge_kw": 0.0,
                     "grid_import_kw": 3.0,
@@ -168,6 +191,7 @@ mod tests {
                 on_threshold_kw: 0.05,
             }),
             ev: None,
+            boiler: None,
         }
     }
 
@@ -223,6 +247,27 @@ mod tests {
                 assert_eq!(channels[0].power_kw, 3.6); // first block's planned power
                 assert!(channels[0].enabled); // 3.6 > 0.05
                 assert_eq!(channels[0].target_soc, Some(80.0));
+            }
+            _ => panic!("expected a load payload"),
+        }
+    }
+
+    #[test]
+    fn builds_boiler_load_command_from_controllable_loads() {
+        let mut c = cfg();
+        c.boiler = Some(BoilerPub {
+            controller_id: "boiler".into(),
+            on_threshold_kw: 0.05,
+        });
+        let cmds = commands(&api_json(), &c, 5, utc("2026-06-23T12:00:05Z"));
+        let boiler = &cmds.iter().find(|(id, _)| id == "boiler").unwrap().1;
+        match &boiler.payload {
+            Payload::Load { channels } => {
+                assert_eq!(channels.len(), 1);
+                assert_eq!(channels[0].channel, "water heat-pump");
+                assert_eq!(channels[0].power_kw, 2.0); // first block's planned draw
+                assert!(channels[0].enabled); // 2.0 > 0.05
+                assert_eq!(channels[0].target_soc, None);
             }
             _ => panic!("expected a load payload"),
         }

--- a/controllers/publisher/src/config.rs
+++ b/controllers/publisher/src/config.rs
@@ -32,6 +32,9 @@ pub struct PublisherConfig {
     /// Emit an EV-charger command (for the EV controller) when present.
     #[serde(default)]
     pub ev: Option<EvPub>,
+    /// Emit a controllable-load command (for the boiler controller) when present.
+    #[serde(default)]
+    pub boiler: Option<BoilerPub>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -81,6 +84,15 @@ pub struct EvPub {
     pub on_threshold_kw: f64,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct BoilerPub {
+    #[serde(default = "default_boiler_id")]
+    pub controller_id: String,
+    /// A controllable load is "on" when its planned first-block power exceeds this (kW).
+    #[serde(default = "default_on_threshold_kw")]
+    pub on_threshold_kw: f64,
+}
+
 fn default_mpc_url() -> String {
     "http://127.0.0.1:3000/api/plan/latest".to_string()
 }
@@ -101,6 +113,9 @@ fn default_heating_id() -> String {
 }
 fn default_ev_id() -> String {
     "ev".to_string()
+}
+fn default_boiler_id() -> String {
+    "boiler".to_string()
 }
 fn default_on_threshold_kw() -> f64 {
     0.05

--- a/controllers/publisher/src/plan.rs
+++ b/controllers/publisher/src/plan.rs
@@ -42,6 +42,10 @@ pub struct FirstStep {
     pub hour_start: DateTime<Utc>,
     #[serde(default)]
     pub heat_kw: HashMap<String, f64>,
+    /// Controllable scheduled-load draw (kW) per load for the coming block (`on · rated_kw`) — the
+    /// boiler controller's setpoint. Empty when no controllable load is configured.
+    #[serde(default)]
+    pub controllable_load_kw: HashMap<String, f64>,
     pub mode: ModeStep,
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,7 +70,8 @@ it in the envelope above.
   - `passive` (default): free-response drift (summer). `window_hours` default 24, `warmup_hours` default 48.
   - `active`: driven by recorded heating relays; **fits** internal gains and returns `{before, after, gains_w}` (before/after = per-zone scores without/with the fitted gains). `start`/`stop` are Flux ranges (default `-{warmup+window}h` .. `now()`).
 - **`GET /api/calibration/gains`** — the live internal-gain self-correction, plus each scheduled
-  load's magnitude (`source` is `"configured"` when `power_w` is set, else `"fitted"`):
+  load's magnitude (`source` is `"measured"` when a `sensor` drives the flux from the real draw,
+  `"configured"` when `power_w` is set, else `"fitted"`):
 
 ```json
 { "live": { "fitted_at": "…", "window_days": 7, "gains_w": {"livingroom": 83, …},

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -277,6 +277,10 @@ learns the per-zone internal gains), or **monitored from a live signal** (`senso
 calibration/backtest derives the flux from the appliance's real electrical draw). The model applies
 `magnitude × profile` as a flux in both the optimizer prediction and the backtest/fit drive.
 
+A scheduled load can additionally be marked **`controllable`** — then it isn't a fixed-schedule flux
+but a **deferrable electrical load the optimizer switches** (load-shifting): see
+[Controllable loads](#controllable-loads-load-shifting) below.
+
 ```json5
 scheduled_loads: [
   {
@@ -303,7 +307,9 @@ scheduled_loads: [
 | `kind` | — | `"sink"` (−, cools) or `"source"` (+, heats) — fixes the sign of the magnitude |
 | `power_w` | W | optional; **set** (> 0) to fix the draw, the model uses it as-is and the calibration won't touch it; **omit** to auto-fit. With a `sensor` this stays the **forecast** magnitude |
 | `sensor` | — | optional [data source](data-sources.md) reading the appliance's **electrical power** (W). When set, the calibration/backtest derives the flux from this *measured* draw; never a fit candidate |
-| `power_factor` | — | optional (default `1.0`); the fraction of measured electrical power that becomes **zone heat**: `1.0` for a resistive source, `≈ COP − 1` for a heat-pump sink. Flux = `P_elec × power_factor`, sign from `kind`. Only used with a `sensor` |
+| `power_factor` | — | optional (default `1.0`); the fraction of electrical power that becomes **zone heat**: `1.0` for a resistive source, `≈ COP − 1` for a heat-pump sink. Heat flux = `P × power_factor`, sign from `kind`. Used with a `sensor` (scales the measured draw) and for a `controllable` load (scales its rated `power_w`) |
+| `controllable` | — | optional (default `false`). `true` ⇒ the optimizer **switches** this load on/off within its windows to run for `run_hours` at the cheapest blocks (load-shifting). Requires `power_w` and `run_hours`. See [below](#controllable-loads-load-shifting) |
+| `run_hours` | h | required when `controllable` (> 0): the run-time the optimizer must schedule within the windows |
 | `windows[].months` | 1–12 | optional; empty ⇒ every month |
 | `windows[].start` / `end` | `"HH:MM"` | local civil time; `start` inclusive, `end` exclusive; `end ≤ start` wraps past midnight |
 
@@ -332,6 +338,48 @@ Miniserver → InfluxDB** path (a smart socket reports its power, the Miniserver
 addressed by an `{ type: "influx", … }` locator. The feature **ships dormant**: with no `sensor`
 configured (or its signal not yet wired into InfluxDB) the load behaves exactly as before
 (`power_w`/fitted), so it can be turned on per appliance once the signal is flowing.
+
+#### Controllable loads (load-shifting)
+
+Set **`controllable: true`** to turn a scheduled load from a *passive* flux into a **deferrable
+electrical load the optimizer switches** — the boiler / domestic-hot-water scenario. Instead of
+running on a fixed schedule, the optimizer chooses *when* to run it **within its `windows`** so that it
+accumulates `run_hours` of run-time at the **cheapest blocks** (responding to the spot price exactly
+like the underfloor heating, but as a simple relay).
+
+```json5
+scheduled_loads: [
+  {
+    zone: "technical_room",     // where its waste heat lands (the air node)
+    label: "boiler",            // the schedule / controller channel key
+    kind: "source",             // "source" warms the room while it runs; "sink" cools it
+    controllable: true,         // the optimizer switches it (default false = passive flux)
+    power_w: 2000,              // REQUIRED: the rated electrical draw (W) priced when on
+    run_hours: 3,               // REQUIRED: run-time to schedule within the windows (h)
+    power_factor: 0.1,          // fraction of the draw that heats the ROOM (rest goes into the tank)
+    windows: [                  // the load-shift may run only inside these local-time windows
+      { start: "00:00", end: "06:00" },  // e.g. the cheap overnight window
+    ],
+  },
+]
+```
+
+What the optimizer does with it, end to end:
+
+- **Decision** — a per-block on/off relay, forced off outside the `windows`. Its rated `power_w` is
+  added to the house electrical load (met from solar / battery / grid) and **priced at the import
+  tariff**, so running it is a real cost the optimizer shifts to cheap blocks — the load-shift.
+- **Run-hours** — a *soft* target: `Σ on·dt ≥ run_hours`, slack-penalized, so a window too short to
+  fit `run_hours` simply runs as much as it can rather than making the plan infeasible.
+- **Heat-when-on** — its `kind × power_w × power_factor` air-node heat couples into the thermal
+  prediction **only in the blocks it runs** (a resistive boiler with `power_factor ≈ 1` dumps all of
+  it into the room; a tank that carries the heat away uses a small factor). So scheduling it warms (or,
+  for a `sink`, cools) the room exactly when it runs, and the comfort band sees it.
+
+The reported schedule is in the plan's `controllable_load_kw` (per load, per block; `on · power_w`),
+surfaced in `first_step` and the timeline, and republished to the dry-run boiler controller (see
+[controllers.md](controllers.md)). **Ships dormant:** `controllable` defaults to `false`, so an
+existing scheduled load is unchanged — the plan is byte-identical until you opt a load in.
 
 ### Loop knobs (all optional, with defaults)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,9 +272,10 @@ Optional. A **scheduled load** is a known appliance that injects or removes heat
 node** on a daily/seasonal schedule the physics model has no source for — e.g. a domestic-hot-water
 heat pump that draws heat *out* of its room while it runs, or a wood stove lit on a routine. You
 declare the **direction** and the **schedule**; the magnitude (W) is either **set** (`power_w`, when
-you know the draw) or **learnt from measured data** (omit `power_w` — the same trajectory fit that
-learns the per-zone internal gains). The model applies `magnitude × profile` as a flux in both the
-optimizer prediction and the backtest/fit drive.
+you know the draw), **learnt from measured data** (omit `power_w` — the same trajectory fit that
+learns the per-zone internal gains), or **monitored from a live signal** (`sensor` — the
+calibration/backtest derives the flux from the appliance's real electrical draw). The model applies
+`magnitude × profile` as a flux in both the optimizer prediction and the backtest/fit drive.
 
 ```json5
 scheduled_loads: [
@@ -283,6 +284,10 @@ scheduled_loads: [
     label: "water heat-pump",   // optional; for logs/reports
     kind: "sink",               // "sink" removes heat (cools the room) | "source" adds heat
     power_w: 800,               // optional: set to fix the draw (W); omit to auto-fit from data
+    // optional: monitor the real draw — derive the historical flux from the measured power (W). The
+    // schedule + power_w stay the forecast; only the calibration/backtest read this signal.
+    sensor: { type: "influx", bucket: "loxone", measurement: "power", field: "hp_power_w" },
+    power_factor: 2.0,          // multiple of P_elec that becomes ZONE heat (≈ COP−1 for a heat-pump sink)
     windows: [                  // local civil-time windows the load is active
       { months: [5, 6, 7, 8, 9],          start: "10:00", end: "20:00" }, // summer: daytime
       { months: [10, 11, 12, 1, 2, 3, 4], start: "01:00", end: "05:00" }, // winter: overnight
@@ -296,7 +301,9 @@ scheduled_loads: [
 | `zone` | — | zone whose **air node** the flux lands at; must exist in `model.json5` |
 | `label` | — | optional display name (logs, the active-backtest report) |
 | `kind` | — | `"sink"` (−, cools) or `"source"` (+, heats) — fixes the sign of the magnitude |
-| `power_w` | W | optional; **set** (> 0) to fix the draw, the model uses it as-is and the calibration won't touch it; **omit** to auto-fit |
+| `power_w` | W | optional; **set** (> 0) to fix the draw, the model uses it as-is and the calibration won't touch it; **omit** to auto-fit. With a `sensor` this stays the **forecast** magnitude |
+| `sensor` | — | optional [data source](data-sources.md) reading the appliance's **electrical power** (W). When set, the calibration/backtest derives the flux from this *measured* draw; never a fit candidate |
+| `power_factor` | — | optional (default `1.0`); the fraction of measured electrical power that becomes **zone heat**: `1.0` for a resistive source, `≈ COP − 1` for a heat-pump sink. Flux = `P_elec × power_factor`, sign from `kind`. Only used with a `sensor` |
 | `windows[].months` | 1–12 | optional; empty ⇒ every month |
 | `windows[].start` / `end` | `"HH:MM"` | local civil time; `start` inclusive, `end` exclusive; `end ≤ start` wraps past midnight |
 
@@ -307,8 +314,24 @@ the windowed effect to the load rather than smearing it into the always-on inter
 and a time-localized load are collinear against a single mean, but separate against the per-hour
 trajectory). A fitted load whose window doesn't overlap the fit window, or that barely moves any zone,
 is dropped (fitted to 0) and logged; a fixed load always applies. Each load's magnitude in use (and
-whether it's `configured` or `fitted`) is surfaced under `/api/calibration/gains` → `live.scheduled`.
-The schedule is **local** time — set `site.utc_offset_hours` correctly.
+whether it's `configured`, `fitted`, or `measured`) is surfaced under `/api/calibration/gains` →
+`live.scheduled`. The schedule is **local** time — set `site.utc_offset_hours` correctly.
+
+**Add a `sensor`** to monitor the appliance's *real* electrical power and **derive** the zone heat
+flux from the measured draw — the most robust option for an appliance that runs irregularly (an
+away week, a variable run length): the calibration/backtest is grounded in the actual run rather than
+an assumed schedule magnitude. The schedule (`windows`/`months`) still gates *when* the flux applies
+(the seasonal duct stays authoritative), and `power_w` stays the **forecast** magnitude (the future
+draw isn't knowable, so the live plan can't read a sensor). Per step the historical drive applies
+`sign × P_elec × power_factor`: set `power_factor ≈ 1.0` for a resistive heater (all the electricity
+becomes room heat) or `≈ COP − 1` for a heat-pump **sink** (it removes `P·(COP−1)` from the room while
+moving the rest into its tank). A sensor-driven load is a **known** input, never fitted (its measured
+flux is already in the calibration baseline). The `sensor` is a [data source](data-sources.md) like
+the zone temperatures — for the house's water heat-pump that means a **Loxone Smart Socket → Loxone
+Miniserver → InfluxDB** path (a smart socket reports its power, the Miniserver writes it to Influx),
+addressed by an `{ type: "influx", … }` locator. The feature **ships dormant**: with no `sensor`
+configured (or its signal not yet wired into InfluxDB) the load behaves exactly as before
+(`power_w`/fitted), so it can be turned on per appliance once the signal is flowing.
 
 ### Loop knobs (all optional, with defaults)
 

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -173,6 +173,25 @@ virtual inputs — `<stem>_kw` (modulating power setpoint), `<stem>_on` (enable)
 reads `_kw`; an on/off one reads `_on`. Wire those into the wallbox logic exactly as for heating
 (AND-ed with your safety interlocks); the deadman defaults to `hold`. Full feature docs: [ev.md](ev.md).
 
+### Boiler (`mpc-controller-boiler`) — controllable-load path (stub)
+
+When a scheduled load is marked **`controllable`** (the boiler / hot-water scenario — see
+[configuration.md](configuration.md#controllable-loads-load-shifting)), the MPC load-shifts it and
+reports the per-block on/off schedule in `first_step.controllable_load_kw`. With a `boiler` block in
+the publisher config, the publisher emits a generic **`load`** payload — one `LoadChannel` per
+controllable load (`channel` = the load's label/zone, `power_kw` = the coming block's planned draw,
+`enabled` = the MPC's on/off decision for that block — the publisher sets it from its
+`on_threshold_kw`) — reusing the same `Payload::Load` envelope as the EV path.
+
+`mpc-controller-boiler` subscribes `mpc/control/boiler`, gates the command exactly like every other
+controller (version / addressee / `command_seq` / deadman), and translates the channels into a
+device command. **It is a stub:** the real boiler hardware (a Modbus relay / smart socket) isn't wired
+yet, so `translate` produces only a logged **would-send** record (`stub://<target>  <channel>_kw=…;
+<channel>_on=…`) — it never drives a device, even with `armed: true`. The scaffold around it
+(subscribe, two-key arm, deadman with `hold` / `all_off` failsafe, dry-run default, status/health) is
+complete; when the Modbus boiler arrives, only `translate.rs` grows the real datagram. Config:
+[`controllers/boiler/boiler.example.json5`](../controllers/boiler/boiler.example.json5).
+
 ## Dry-run, arming, and the deadman (safety)
 
 - **Dry-run is the default everywhere.** A controller computes and logs the device messages it *would*
@@ -213,6 +232,7 @@ cargo run -p mpc-plan-publisher -- controllers/publisher/publisher.json5
 cargo run -p mpc-controller-growatt -- controllers/growatt/growatt.json5
 cargo run -p mpc-controller-heating -- controllers/heating/heating.json5
 cargo run -p mpc-controller-ev      -- controllers/ev/ev.example.json5
+cargo run -p mpc-controller-boiler  -- controllers/boiler/boiler.example.json5
 ```
 
 With the publisher armed against a local broker (and the controllers still dry-run), you can watch the

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -167,6 +167,14 @@ its SoC / target / wallbox-power signals by `SourceLocator`, so the same charger
 comes from Influx, a TeslaMate Postgres DB, a Tesla HTTP bridge, or an MQTT topic via the sidecar —
 with no code change.
 
+## Scheduled-load sensors
+
+A **scheduled load** (`docs/configuration.md`) can also carry a `sensor` — a `SourceLocator` reading
+the appliance's electrical power (e.g. a Loxone Smart Socket's power in InfluxDB). When set, the
+calibration derives that load's room-heat flux from the *measured* draw (`P × power_factor`) instead
+of a fitted/configured magnitude, while the schedule stays the forecast. Same plug-anywhere seam: the
+power can come from any backend the bridge can feed.
+
 ## Overriding a core signal — the `data_sources` block
 
 The same `SourceLocator` mechanism is wired into the core reads through an optional top-level

--- a/src/app.rs
+++ b/src/app.rs
@@ -392,7 +392,7 @@ pub struct GainsSnapshot {
     /// The fitted per-zone internal gains (W) now in use by the plan.
     pub gains_w: HashMap<String, f64>,
     /// Per scheduled-load magnitude (W) now in use, aligned to `config.scheduled_loads` — each tagged
-    /// with whether it was `configured` (`power_w` set) or `fitted` (learnt from data).
+    /// `configured` (`power_w` set), `fitted` (learnt from data), or `measured` (driven by a `sensor`).
     pub scheduled: Vec<ScheduledFit>,
 }
 
@@ -403,9 +403,11 @@ pub struct ScheduledFit {
     pub label: String,
     /// The zone whose air node the load acts on.
     pub zone: String,
-    /// The magnitude in use (W, ≥ 0); the sign comes from the load's `kind`.
+    /// The magnitude in use (W, ≥ 0); the sign comes from the load's `kind`. For a `"measured"` load
+    /// this is the configured **forecast** magnitude (`power_w`, or 0) — the live flux tracks the sensor.
     pub magnitude_w: f64,
-    /// `"configured"` if `power_w` was set, else `"fitted"`.
+    /// `"measured"` if a `sensor` drives the flux from the real draw, else `"configured"` if `power_w`
+    /// was set, else `"fitted"` (learnt from data).
     pub source: String,
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -371,6 +371,10 @@ pub struct TimelineBlock {
     pub cool_kw: HashMap<String, f64>,
     /// HVAC air-side heating power (kW) per HVAC zone.
     pub hvac_heat_kw: HashMap<String, f64>,
+    /// Controllable scheduled-load draw (kW) per load this block (`on · rated_kw`) — the load-shift
+    /// schedule. Empty when no controllable load is configured.
+    #[serde(default)]
+    pub controllable_load_kw: HashMap<String, f64>,
     /// **Predicted** air temperature (°C) per controlled zone at the end of the block.
     pub temp_c: HashMap<String, f64>,
     /// Recommended Growatt slot mode and the price-gated export / inverter levers — applied by the
@@ -434,6 +438,10 @@ pub struct FirstStep {
     pub cool_kw: HashMap<String, f64>,
     /// HVAC air-side heating power (kW) per HVAC zone for the coming block.
     pub hvac_heat_kw: HashMap<String, f64>,
+    /// Controllable scheduled-load draw (kW) per load for the coming block (`on · rated_kw`, 0 when
+    /// off) — the boiler controller's setpoint. Empty when no controllable load is configured.
+    #[serde(default)]
+    pub controllable_load_kw: HashMap<String, f64>,
     pub battery_charge_kw: f64,
     pub battery_discharge_kw: f64,
     pub grid_import_kw: f64,
@@ -866,6 +874,7 @@ pub async fn current_plan(
                 heat_kw: at_block(&plan.heat_kw, b),
                 cool_kw: at_block(&plan.cool_kw, b),
                 hvac_heat_kw: at_block(&plan.hvac_heat_kw, b),
+                controllable_load_kw: at_block(&plan.controllable_load_kw, b),
                 temp_c: at_block(&plan.zone_temp_c, b),
                 slot: classify_mode(
                     charge,
@@ -894,6 +903,7 @@ pub async fn current_plan(
         heat_kw: first_of(&plan.heat_kw),
         cool_kw: first_of(&plan.cool_kw),
         hvac_heat_kw: first_of(&plan.hvac_heat_kw),
+        controllable_load_kw: first_of(&plan.controllable_load_kw),
         battery_charge_kw: first(&plan.charge_kw),
         battery_discharge_kw: first(&plan.discharge_kw),
         grid_import_kw: first(&plan.grid_import_kw),

--- a/src/estimate.rs
+++ b/src/estimate.rs
@@ -86,6 +86,11 @@ pub struct DriveData {
     /// Fitted magnitude (W, ≥ 0) of each [`Self::scheduled_loads`] entry, aligned 1:1. The probe in
     /// [`crate::validate::fit_gains`] overwrites a single entry to measure its response.
     pub scheduled_w: Vec<f64>,
+    /// Optional **measured** electrical-power series (W) per [`Self::scheduled_loads`] entry, aligned
+    /// 1:1 and each (when `Some`) on [`Self::hours`]. A load with a `sensor` derives its flux from this
+    /// measured draw (`sign × P_elec[h] × power_factor`, still gated by the windows/months) instead of
+    /// `scheduled_w × unit_profile`; `None` ⇒ no sensor (the magnitude path is used). Empty ⇒ all-None.
+    pub sensor_power_w: Vec<Option<Vec<f64>>>,
     /// Site-local civil-time offset, for evaluating the scheduled-load windows (month / minute-of-day).
     pub local_offset: chrono::FixedOffset,
 }
@@ -150,6 +155,7 @@ pub async fn read_drive_data(
         internal_gain_w: HashMap::new(),
         scheduled_loads: Vec::new(),
         scheduled_w: Vec::new(),
+        sensor_power_w: Vec::new(),
         local_offset: chrono::FixedOffset::east_opt(0).unwrap(),
     })
 }
@@ -280,9 +286,22 @@ pub fn drive(
         for (zone, &gain_w) in &data.internal_gain_w {
             *air_flux_w.entry(zone.as_str()).or_insert(0.0) += gain_w;
         }
-        for (load, &w) in data.scheduled_loads.iter().zip(&data.scheduled_w) {
-            *air_flux_w.entry(load.zone.as_str()).or_insert(0.0) +=
-                w * load.unit_profile(month, minute);
+        for (i, load) in data.scheduled_loads.iter().enumerate() {
+            // The signed unit profile (±1 active, 0 outside the window/months) — the seasonal duct stays
+            // authoritative for *when* the load is on. A sensor-driven load derives its magnitude from
+            // the measured electrical draw (`P_elec × power_factor`); all others use the fitted/configured
+            // `scheduled_w` magnitude. Both carry the sign through `unit_profile`.
+            let profile = load.unit_profile(month, minute);
+            if profile == 0.0 {
+                continue;
+            }
+            let magnitude = match data.sensor_power_w.get(i).and_then(Option::as_ref) {
+                Some(series) => {
+                    series.get(h).copied().unwrap_or(0.0) * load.power_factor.unwrap_or(1.0)
+                }
+                None => data.scheduled_w.get(i).copied().unwrap_or(0.0),
+            };
+            *air_flux_w.entry(load.zone.as_str()).or_insert(0.0) += magnitude * profile;
         }
         for (zone, flux_w) in air_flux_w {
             if let Some(&node) = net.zone_indices.get(zone) {

--- a/src/mpc_loop.rs
+++ b/src/mpc_loop.rs
@@ -117,8 +117,16 @@ pub async fn run(state: Arc<AppState>, tick: Duration) {
                             load.label.clone()
                         },
                         zone: load.zone.clone(),
-                        magnitude_w: w,
-                        source: if load.power_w.is_some() {
+                        // A sensor-driven load's flux is the *measured* draw (not in `scheduled_w`, which
+                        // the fit leaves untouched for it); report the configured forecast magnitude.
+                        magnitude_w: if load.sensor.is_some() {
+                            load.power_w.unwrap_or(0.0)
+                        } else {
+                            w
+                        },
+                        source: if load.sensor.is_some() {
+                            "measured".to_string()
+                        } else if load.power_w.is_some() {
                             "configured".to_string()
                         } else {
                             "fitted".to_string()

--- a/src/optimize/config.rs
+++ b/src/optimize/config.rs
@@ -90,9 +90,26 @@ pub struct ScheduledLoad {
     pub kind: LoadKind,
     /// Magnitude (W, > 0) when the draw is **known**: the model uses it as-is and the calibration does
     /// not fit it. Omit to have the calibration **learn** it from data (the default). The sign always
-    /// comes from `kind` — this is the unsigned watts.
+    /// comes from `kind` — this is the unsigned watts. When a `sensor` is set this stays the
+    /// **forecast** magnitude (the future draw isn't knowable); the historical drive uses the measured
+    /// signal instead.
     #[serde(default)]
     pub power_w: Option<f64>,
+    /// Optional live signal reading the appliance's **electrical power** (W). When set, the
+    /// calibration/backtest drive derives the zone heat flux from this *measured* draw (gated by the
+    /// `windows`/`months` schedule) rather than from `power_w` or a fitted magnitude — so it stays
+    /// grounded in the real run (robust to away weeks and variable run length). A sensor-driven load is
+    /// a **known** input, never a fit candidate. Reuses the read-only [`SourceLocator`] layer (e.g. a
+    /// Loxone smart socket's power landing in InfluxDB); the forecast path is unchanged (the future draw
+    /// isn't knowable). Empty ⇒ no sensor (the magnitude is `power_w`/fitted as before).
+    #[serde(default)]
+    pub sensor: Option<SourceLocator>,
+    /// The fraction of the measured electrical power that becomes **zone heat** (effective default
+    /// `1.0`). A resistive source dissipates all of it (`1.0`); a heat-pump **sink** removes
+    /// `P·(COP−1)` from the room (so ≈ `COP − 1`). The flux magnitude per step is
+    /// `P_elec × power_factor`, with the sign from `kind`. Only used with a `sensor`.
+    #[serde(default)]
+    pub power_factor: Option<f64>,
     /// Local-time windows the load is active in. Empty ⇒ never active.
     pub windows: Vec<LoadWindow>,
 }
@@ -1023,6 +1040,15 @@ impl ControlConfig {
                     load.zone
                 );
             }
+            // `power_factor` scales the measured electrical power into zone heat (P·factor); it feeds the
+            // drive flux directly, so a NaN/≤0 would silently corrupt the calibration. Reject at load.
+            if let Some(f) = load.power_factor {
+                anyhow::ensure!(
+                    f.is_finite() && f > 0.0,
+                    "scheduled_load zone {:?}: power_factor must be finite and > 0 (got {f})",
+                    load.zone
+                );
+            }
             for w in &load.windows {
                 anyhow::ensure!(
                     parse_hm(&w.start).is_some() && parse_hm(&w.end).is_some(),
@@ -1105,6 +1131,8 @@ mod tests {
             label: "water heat-pump".into(),
             kind: LoadKind::Sink,
             power_w: None,
+            sensor: None,
+            power_factor: None,
             windows: vec![
                 win(&[5, 6, 7, 8, 9], "10:00", "20:00"),
                 win(&[10, 11, 12, 1, 2, 3, 4], "01:00", "05:00"),
@@ -1165,6 +1193,35 @@ mod tests {
         )
         .unwrap();
         assert!(bad_power.validate_scheduled_loads().is_err());
+
+        // A `sensor`-driven load parses (a SourceLocator) and a valid `power_factor` passes; the
+        // forecast magnitude (`power_w`) and the schedule remain.
+        let sensor_ok = ControlConfig::from_json5(
+            r#"{ site:{latitude:50,longitude:14,utc_offset_hours:1},
+                 heating:{cop:1,comfort_penalty:0,zones:{}},
+                 scheduled_loads:[{zone:"x",kind:"sink",power_w:800,power_factor:2.5,
+                   sensor:{type:"influx",bucket:"loxone",measurement:"power",field:"hp_w"},
+                   windows:[{start:"01:00",end:"05:00"}]}] }"#,
+        )
+        .unwrap();
+        assert!(sensor_ok.scheduled_loads[0].sensor.is_some());
+        assert_eq!(sensor_ok.scheduled_loads[0].power_factor, Some(2.5));
+        assert!(sensor_ok.validate_scheduled_loads().is_ok());
+
+        // A non-positive / non-finite `power_factor` is rejected (it scales the measured flux directly).
+        for bad in ["0", "-1", "NaN"] {
+            let cfg = ControlConfig::from_json5(&format!(
+                r#"{{ site:{{latitude:50,longitude:14,utc_offset_hours:1}},
+                     heating:{{cop:1,comfort_penalty:0,zones:{{}}}},
+                     scheduled_loads:[{{zone:"x",kind:"sink",power_factor:{bad},
+                       windows:[{{start:"01:00",end:"05:00"}}]}}] }}"#,
+            ))
+            .unwrap();
+            assert!(
+                cfg.validate_scheduled_loads().is_err(),
+                "power_factor {bad} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/src/optimize/config.rs
+++ b/src/optimize/config.rs
@@ -107,11 +107,35 @@ pub struct ScheduledLoad {
     /// The fraction of the measured electrical power that becomes **zone heat** (effective default
     /// `1.0`). A resistive source dissipates all of it (`1.0`); a heat-pump **sink** removes
     /// `P·(COP−1)` from the room (so ≈ `COP − 1`). The flux magnitude per step is
-    /// `P_elec × power_factor`, with the sign from `kind`. Only used with a `sensor`.
+    /// `P_elec × power_factor`, with the sign from `kind`. Used for the air-node heat both with a
+    /// `sensor` (scaling the measured draw) and for a `controllable` load (scaling its rated `power_w`).
     #[serde(default)]
     pub power_factor: Option<f64>,
+    /// When `true`, the load is **switched by the optimizer** instead of following a fixed schedule:
+    /// it is a deferrable electrical load (e.g. a resistive boiler / domestic-hot-water tank) the LP
+    /// turns on/off *within its `windows`* to run for `run_hours`, picking the cheapest blocks
+    /// (load-shifting). Its `power_w` is then the **rated electrical draw** (required), priced at the
+    /// import tariff when on, and its air-node heat (`kind × power_w × power_factor`) couples into the
+    /// thermal prediction only in the blocks it runs. Default `false` ⇒ the load is a **passive**
+    /// scheduled flux as before (the plan is byte-identical). See `docs/configuration.md`.
+    #[serde(default)]
+    pub controllable: bool,
+    /// For a `controllable` load: the total run time required within the windows (hours, > 0). The
+    /// optimizer schedules `run_hours` of on-time at the cheapest blocks in the window (soft — an
+    /// infeasible window just runs as much as it can). Required when `controllable`; ignored otherwise.
+    #[serde(default)]
+    pub run_hours: Option<f64>,
     /// Local-time windows the load is active in. Empty ⇒ never active.
     pub windows: Vec<LoadWindow>,
+}
+
+impl ScheduledLoad {
+    /// The unsigned air-node heat (kW) when a `controllable` load is **on**, scaled by `power_factor`
+    /// (effective `1.0`). The optimizer applies it with the load's sign via the kernel. `power_w` is
+    /// the rated electrical draw; a resistive boiler dissipates all of it as heat (`power_factor` 1).
+    pub fn controllable_heat_kw(&self) -> f64 {
+        self.power_w.unwrap_or(0.0) * self.power_factor.unwrap_or(1.0) / 1000.0
+    }
 }
 
 /// The direction of a [`ScheduledLoad`] — the sign of its (fitted, non-negative) magnitude.
@@ -1027,6 +1051,9 @@ impl ControlConfig {
     /// month must be 1-12, so a typo fails fast instead of silently never firing (see
     /// [`LoadWindow::contains`]'s defensive `false`).
     fn validate_scheduled_loads(&self) -> Result<()> {
+        // Controllable loads are keyed by name (label, else zone) in the plan output + the thermal
+        // kernel map, so two with the same name would silently collide — reject duplicates.
+        let mut controllable_names = std::collections::HashSet::new();
         for load in &self.scheduled_loads {
             anyhow::ensure!(
                 !load.windows.is_empty(),
@@ -1047,6 +1074,32 @@ impl ControlConfig {
                     f.is_finite() && f > 0.0,
                     "scheduled_load zone {:?}: power_factor must be finite and > 0 (got {f})",
                     load.zone
+                );
+            }
+            // A controllable load is a deferrable electrical load the optimizer switches: it needs a
+            // rated draw (`power_w`, the LP's electrical and heat magnitude) and a positive `run_hours`
+            // target, plus at least one window (already enforced above) to shift within. A `sensor` is
+            // a *monitoring* feature (read a past draw), orthogonal to *control*; it is allowed but the
+            // forecast magnitude still comes from `power_w`.
+            if load.controllable {
+                anyhow::ensure!(
+                    load.power_w.is_some_and(|w| w.is_finite() && w > 0.0),
+                    "scheduled_load zone {:?}: a controllable load needs power_w set and > 0 (the rated draw)",
+                    load.zone
+                );
+                anyhow::ensure!(
+                    load.run_hours.is_some_and(|h| h.is_finite() && h > 0.0),
+                    "scheduled_load zone {:?}: a controllable load needs run_hours set and > 0",
+                    load.zone
+                );
+                let name = if load.label.is_empty() {
+                    &load.zone
+                } else {
+                    &load.label
+                };
+                anyhow::ensure!(
+                    controllable_names.insert(name.clone()),
+                    "duplicate controllable load name {name:?} — controllable loads need distinct labels (the plan/kernel key)"
                 );
             }
             for w in &load.windows {
@@ -1133,6 +1186,8 @@ mod tests {
             power_w: None,
             sensor: None,
             power_factor: None,
+            controllable: false,
+            run_hours: None,
             windows: vec![
                 win(&[5, 6, 7, 8, 9], "10:00", "20:00"),
                 win(&[10, 11, 12, 1, 2, 3, 4], "01:00", "05:00"),
@@ -1220,6 +1275,61 @@ mod tests {
             assert!(
                 cfg.validate_scheduled_loads().is_err(),
                 "power_factor {bad} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_scheduled_loads_gates_controllable() {
+        // A well-formed controllable load (rated draw + run_hours + a window) passes and parses.
+        let ok = ControlConfig::from_json5(
+            r#"{ site:{latitude:50,longitude:14,utc_offset_hours:1},
+                 heating:{cop:1,comfort_penalty:0,zones:{}},
+                 scheduled_loads:[{zone:"technical_room",kind:"source",controllable:true,
+                   power_w:2000,run_hours:3,windows:[{start:"00:00",end:"06:00"}]}] }"#,
+        )
+        .unwrap();
+        let load = &ok.scheduled_loads[0];
+        assert!(load.controllable);
+        assert_eq!(load.run_hours, Some(3.0));
+        assert_eq!(load.power_w, Some(2000.0));
+        assert!(ok.validate_scheduled_loads().is_ok());
+        // The on-heat is rated × power_factor (default 1.0): 2 kW.
+        assert!((load.controllable_heat_kw() - 2.0).abs() < 1e-9);
+
+        // Controllable without `power_w` is rejected (the LP has no rated draw / heat magnitude).
+        let no_power = ControlConfig::from_json5(
+            r#"{ site:{latitude:50,longitude:14,utc_offset_hours:1},
+                 heating:{cop:1,comfort_penalty:0,zones:{}},
+                 scheduled_loads:[{zone:"x",kind:"source",controllable:true,run_hours:2,
+                   windows:[{start:"00:00",end:"06:00"}]}] }"#,
+        )
+        .unwrap();
+        assert!(no_power.validate_scheduled_loads().is_err());
+
+        // Two controllable loads sharing a name (label, else zone) collide on the plan/kernel key.
+        let dup = ControlConfig::from_json5(
+            r#"{ site:{latitude:50,longitude:14,utc_offset_hours:1},
+                 heating:{cop:1,comfort_penalty:0,zones:{}},
+                 scheduled_loads:[
+                   {zone:"a",kind:"source",controllable:true,power_w:1000,run_hours:1,windows:[{start:"00:00",end:"06:00"}]},
+                   {zone:"a",kind:"source",controllable:true,power_w:1000,run_hours:1,windows:[{start:"00:00",end:"06:00"}]}] }"#,
+        )
+        .unwrap();
+        assert!(dup.validate_scheduled_loads().is_err());
+
+        // Controllable without `run_hours` (or non-positive) is rejected.
+        for run in ["", ",run_hours:0", ",run_hours:-1"] {
+            let cfg = ControlConfig::from_json5(&format!(
+                r#"{{ site:{{latitude:50,longitude:14,utc_offset_hours:1}},
+                     heating:{{cop:1,comfort_penalty:0,zones:{{}}}},
+                     scheduled_loads:[{{zone:"x",kind:"source",controllable:true,power_w:2000{run},
+                       windows:[{{start:"00:00",end:"06:00"}}]}}] }}"#,
+            ))
+            .unwrap();
+            assert!(
+                cfg.validate_scheduled_loads().is_err(),
+                "run_hours {run:?} should be rejected for a controllable load"
             );
         }
     }

--- a/src/optimize/coordinator.rs
+++ b/src/optimize/coordinator.rs
@@ -25,7 +25,7 @@ use uom::si::{
 use super::battery::{optimize_dispatch, BatterySpec, DispatchInputs, DispatchPlan};
 use super::config::{HeatingConfig, HvacConfig, ScheduledLoad};
 use super::thermal::build_context;
-use super::unified::{optimize_unified, EvSpec, FlowParams, UnifiedPlan};
+use super::unified::{optimize_unified, ControllableLoadSpec, EvSpec, FlowParams, UnifiedPlan};
 use crate::forecast::consumption::ConsumptionModel;
 use crate::forecast::solar::PvArray;
 use crate::rc_network::RcNetwork;
@@ -236,6 +236,13 @@ fn known_thermal_inputs(
             *air_flux_w.entry(zone.as_str()).or_insert(0.0) += gain_w;
         }
         for (load, &w) in ctx.scheduled_loads.iter().zip(&ctx.scheduled_w) {
+            // A *controllable* load is NOT a passive flux here — the optimizer switches it, and its
+            // heat enters via the kernel scaled by the on/off decision. Including it here too would
+            // double-count it. (Forecast-only: the calibration drive over real past data still applies
+            // its measured/scheduled flux, since the load actually ran then.)
+            if load.controllable {
+                continue;
+            }
             *air_flux_w.entry(load.zone.as_str()).or_insert(0.0) +=
                 w * load.unit_profile(month, minute);
         }
@@ -247,6 +254,47 @@ fn known_thermal_inputs(
         u_known.push(u);
     }
     u_known
+}
+
+/// The stable identifier for a scheduled load — its `label`, or its `zone` when the label is empty.
+/// Used as the controllable-load schedule / kernel key (shared by the plan report and the controller).
+pub fn load_name(load: &ScheduledLoad) -> String {
+    if load.label.is_empty() {
+        load.zone.clone()
+    } else {
+        load.label.clone()
+    }
+}
+
+/// Build the per-block [`ControllableLoadSpec`]s for the optimizer from the context's controllable
+/// scheduled loads. The window for block `i` is `unit_profile != 0` at that block's local time (so the
+/// optimizer can switch the load only inside its configured windows). Non-controllable loads are
+/// skipped (they enter the thermal free-response as a passive flux instead).
+fn controllable_load_specs(ctx: &ForecastContext, n: usize) -> Vec<ControllableLoadSpec> {
+    ctx.scheduled_loads
+        .iter()
+        .filter(|l| l.controllable)
+        .map(|l| {
+            let window: Vec<bool> = (0..n)
+                .map(|h| {
+                    let local = block_midpoint(ctx, h).with_timezone(&ctx.local_offset);
+                    l.unit_profile(local.month(), local.hour() * 60 + local.minute()) != 0.0
+                })
+                .collect();
+            let sign = match l.kind {
+                super::config::LoadKind::Sink => -1.0,
+                super::config::LoadKind::Source => 1.0,
+            };
+            ControllableLoadSpec {
+                name: load_name(l),
+                zone: l.zone.clone(),
+                rated_kw: l.power_w.unwrap_or(0.0) / 1000.0,
+                heat_kw: sign * l.controllable_heat_kw(),
+                window,
+                run_hours: l.run_hours.unwrap_or(0.0),
+            }
+        })
+        .collect()
 }
 
 /// Plan the whole house: drive the unified battery + heating optimizer from the forecasts.
@@ -285,6 +333,31 @@ pub fn plan_unified(
         }
     }
     let u_known = known_thermal_inputs(ss, net, ctx, n);
+    // Controllable scheduled loads the optimizer switches (deferrable boiler-style loads); each gets an
+    // air-node kernel so its heat-when-on couples into the comfort prediction. Drop any on an
+    // unmodelled zone (no thermal state ⇒ no kernel): it would otherwise schedule electricity but
+    // couple no heat. Mirrors `build_context`'s kernel filter, kept consistent.
+    let controllable: Vec<ControllableLoadSpec> = controllable_load_specs(ctx, n)
+        .into_iter()
+        .filter(|l| {
+            let modelled = net
+                .zone_indices
+                .get(&l.zone)
+                .and_then(|&node| ss.state_index(node))
+                .is_some();
+            if !modelled {
+                eprintln!(
+                    "  plan_unified: controllable load {:?} on unmodelled zone {:?} — skipping",
+                    l.name, l.zone
+                );
+            }
+            modelled
+        })
+        .collect();
+    let load_sources: Vec<(String, String)> = controllable
+        .iter()
+        .map(|l| (l.name.clone(), l.zone.clone()))
+        .collect();
     // HVAC zones get an air-node actuator/kernel; the outdoor-temp forecast feeds each unit's COP.
     let thermal = build_context(
         ss,
@@ -293,6 +366,7 @@ pub fn plan_unified(
         &u_known,
         ctx.step_seconds,
         &hvac.served_zones(),
+        &load_sources,
     )?;
     let inputs = DispatchInputs {
         dt_hours: ctx.step_seconds / 3600.0,
@@ -317,6 +391,7 @@ pub fn plan_unified(
         &flow,
         &ctx.temperature_c,
         ev,
+        &controllable,
     )
 }
 
@@ -623,5 +698,98 @@ mod tests {
             &[],
         );
         assert!(err.is_err());
+    }
+
+    use super::super::config::{LoadKind, LoadWindow, ScheduledLoad};
+
+    fn boiler_load(controllable: bool) -> ScheduledLoad {
+        ScheduledLoad {
+            zone: "livingroom".to_string(),
+            label: "boiler".to_string(),
+            kind: LoadKind::Source,
+            power_w: Some(2000.0),
+            sensor: None,
+            // Tiny heat fraction: a hot-water boiler dumps most of its energy into the tank/draw, not
+            // the room — so the comfort band doesn't fight the run-hours target in this scheduling test.
+            power_factor: Some(0.02),
+            controllable,
+            run_hours: Some(3.0),
+            // Active all day (months empty, 00:00–24:00 wraps to the whole day via 00:00→00:00).
+            windows: vec![LoadWindow {
+                months: Vec::new(),
+                start: "00:00".to_string(),
+                end: "23:59".to_string(),
+            }],
+        }
+    }
+
+    /// `controllable_load_specs` selects only controllable loads, with the window evaluated per block.
+    #[test]
+    fn controllable_specs_select_only_controllable_loads() {
+        let mut ctx = context();
+        ctx.scheduled_loads = vec![boiler_load(false), boiler_load(true)];
+        ctx.scheduled_w = vec![2000.0, 2000.0];
+        let specs = controllable_load_specs(&ctx, ctx.import_price.len());
+        assert_eq!(specs.len(), 1, "only the controllable load becomes a spec");
+        let s = &specs[0];
+        assert_eq!(s.name, "boiler");
+        assert_eq!(s.zone, "livingroom");
+        assert!((s.rated_kw - 2.0).abs() < 1e-9); // 2000 W rated draw
+        assert!((s.heat_kw - 0.04).abs() < 1e-9); // source sign, 2 kW × factor 0.02 = 0.04 kW
+        assert_eq!(s.run_hours, 3.0);
+        assert!(
+            s.window.iter().all(|&w| w),
+            "all-day window is active every block"
+        );
+    }
+
+    /// A controllable load is wired end-to-end through `plan_unified`: it is scheduled for its
+    /// `run_hours` at the rated power and reported in `controllable_load_kw`. (The pure cheapest-blocks
+    /// proof — with no comfort interaction — is the keystone in `unified.rs`; here a real heated zone is
+    /// involved, so comfort can also pull the load, which is correct behaviour.)
+    #[test]
+    fn plan_unified_schedules_controllable_load_cheap_first() {
+        let (net, ss) = heated_house();
+        let x0 = DVector::from_element(
+            ss.n_states(),
+            ThermodynamicTemperature::new::<degree_celsius>(22.0)
+                .get::<uom::si::thermodynamic_temperature::kelvin>(),
+        );
+        let n = 12;
+        let mut ctx = context();
+        // Trim the all-24h context vectors to n and set a cheap-first / expensive-second price split.
+        ctx.temperature_c.truncate(n);
+        ctx.cloud_cover.truncate(n);
+        ctx.import_price = (0..n).map(|h| if h < n / 2 { 0.1 } else { 0.5 }).collect();
+        ctx.export_price = vec![0.03; n];
+        ctx.export_allowed = vec![true; n];
+        ctx.inverter_on = vec![true; n];
+        ctx.scheduled_loads = vec![boiler_load(true)];
+        ctx.scheduled_w = vec![2000.0];
+
+        let plan = plan_unified(
+            &pv_array(),
+            &consumption_model(),
+            &battery(),
+            &heating_config(),
+            &HvacConfig::default(),
+            &ss,
+            &net,
+            &ctx,
+            &x0,
+            &[],
+            &[],
+        )
+        .unwrap();
+        let draw = &plan.controllable_load_kw["boiler"];
+        assert_eq!(draw.len(), n);
+        // Reported per-block draw is either off (0) or the rated 2 kW (an on/off relay).
+        assert!(
+            draw.iter().all(|&d| d < 1e-6 || (d - 2.0).abs() < 1e-6),
+            "draw is on/off at the rated power: {draw:?}"
+        );
+        // Scheduled for ≈ run_hours (3 h) of run-time at 2 kW ⇒ ≈ 6 kWh total over the horizon.
+        let total: f64 = draw.iter().sum::<f64>(); // × dt(=1 h) = kWh
+        assert!((total - 6.0).abs() < 0.2, "≈3 h × 2 kW scheduled: {draw:?}");
     }
 }

--- a/src/optimize/thermal.rs
+++ b/src/optimize/thermal.rs
@@ -51,22 +51,32 @@ pub struct ThermalContext {
     /// `source`'s **air node** — the HVAC/AC actuator. Positive (air-heating); cooling applies it
     /// with a negative decision. Faster than the slab kernel (no slab lag).
     pub air_kernels: HashMap<(String, String), Vec<f64>>,
+    /// Per `(target, load_name)`: air-temperature response (K) of `target` to a 1 kW pulse at a
+    /// **controllable load's** zone air node, by lag `1..=horizon`. Keyed by the *load name* (not the
+    /// zone) so several loads can act on the same room independently. The optimizer applies it with the
+    /// load's signed per-kW heat when the load is on; it is the same air-node mechanism as
+    /// [`Self::air_kernels`], just driven by the on/off load decision rather than the HVAC decision.
+    pub load_kernels: HashMap<(String, String), Vec<f64>>,
 }
 
 impl ThermalContext {
     /// Predicted air temperature (K) of `zone` at step `k` (`1..=horizon`) for a slab-heating
-    /// schedule `heat[source][j]` (kW) and a **signed** HVAC air schedule `air[source][j]` (kW;
-    /// positive = air-heating, negative = cooling), `j = 0..horizon`. Affine in the decisions — the
-    /// LP builds the same expression symbolically; this evaluates it for reporting/tests.
+    /// schedule `heat[source][j]` (kW), a **signed** HVAC air schedule `air[source][j]` (kW;
+    /// positive = air-heating, negative = cooling), and a **signed** controllable-load air schedule
+    /// `loads[load_name][j]` (kW; the load's per-kW heat × its on/off), `j = 0..horizon`. Affine in
+    /// the decisions — the LP builds the same expression symbolically; this evaluates it for
+    /// reporting/tests.
     ///
     /// `zone` must be one of [`Self::free_response`]'s keys (a controlled zone with a state row);
-    /// callers derive their zone list from there. Pass an empty `air` map when there's no HVAC.
+    /// callers derive their zone list from there. Pass empty `air` / `loads` maps when there is no
+    /// HVAC / no controllable load.
     pub fn predict(
         &self,
         zone: &str,
         k: usize,
         heat: &HashMap<String, Vec<f64>>,
         air: &HashMap<String, Vec<f64>>,
+        loads: &HashMap<String, Vec<f64>>,
     ) -> f64 {
         debug_assert!(
             (1..=self.horizon).contains(&k),
@@ -96,6 +106,19 @@ impl ThermalContext {
                 t += schedule[j] * kernel[k - j - 1];
             }
         }
+        // Each controllable load, by name: its signed per-kW heat applied through the same air-node
+        // kernel (keyed by the load name, target = this zone).
+        for ((target, name), kernel) in &self.load_kernels {
+            if target != zone {
+                continue;
+            }
+            let Some(schedule) = loads.get(name) else {
+                continue;
+            };
+            for j in 0..k {
+                t += schedule[j] * kernel[k - j - 1];
+            }
+        }
         t
     }
 }
@@ -109,6 +132,9 @@ pub fn build_context(
     u_known: &[DVector<f64>],
     dt: f64,
     hvac_zones: &[String],
+    // Controllable scheduled loads, as `(load_name, zone)`: each gets a 1 kW air-node kernel keyed by
+    // its name (see [`ThermalContext::load_kernels`]). Empty ⇒ none, and the result is unchanged.
+    controllable_loads: &[(String, String)],
 ) -> Result<ThermalContext> {
     let n = u_known.len();
 
@@ -138,9 +164,19 @@ pub fn build_context(
     hvac_zones.sort();
     hvac_zones.dedup();
 
-    // Controlled = heated ∪ HVAC zones; free response covers all of them.
+    // Controllable-load source zones with a real state row (skip a load on a reserved/boundary zone).
+    let load_sources: Vec<(String, String)> = controllable_loads
+        .iter()
+        .filter(|(_, zone)| zone_row(zone).is_some())
+        .cloned()
+        .collect();
+
+    // Controlled = heated ∪ HVAC ∪ controllable-load zones; free response covers all of them (a
+    // controllable load's zone gets a comfort band and a temperature prediction even when it has no
+    // heating/HVAC actuator of its own — its load is the only thing acting on the air there).
     let mut controlled = heated_zones.clone();
     controlled.extend(hvac_zones.iter().cloned());
+    controlled.extend(load_sources.iter().map(|(_, zone)| zone.clone()));
     controlled.sort();
     controlled.dedup();
 
@@ -207,6 +243,21 @@ pub fn build_context(
         }
     }
 
+    // Controllable-load kernels: a 1 kW pulse at each controllable load's zone air node — the same
+    // air-node mechanism as the HVAC kernel, but keyed by the *load name* so the LP can scale it by
+    // that load's on/off decision and its signed per-kW heat.
+    let mut load_kernels = HashMap::new();
+    for (name, zone) in &load_sources {
+        let Some(&node) = net.zone_indices.get(zone) else {
+            continue;
+        };
+        let mut e = ss.zero_input();
+        ss.set_flux(&mut e, node, Power::new::<kilowatt>(1.0));
+        for (target, response) in kernel_from(&e) {
+            load_kernels.insert((target, name.clone()), response);
+        }
+    }
+
     Ok(ThermalContext {
         dt,
         horizon: n,
@@ -215,6 +266,7 @@ pub fn build_context(
         free_response,
         kernels,
         air_kernels,
+        load_kernels,
     })
 }
 
@@ -293,7 +345,7 @@ mod tests {
         let (net, ss, x0, u_known, dt, n) = fixture();
         // Treat zone "a" as also HVAC-served (an air-node actuator) on top of both zones' slabs —
         // the keystone check that the affine map matches a full simulate for slab + air fluxes.
-        let ctx = build_context(&ss, &net, &x0, &u_known, dt, &["a".to_string()]).unwrap();
+        let ctx = build_context(&ss, &net, &x0, &u_known, dt, &["a".to_string()], &[]).unwrap();
         assert_eq!(ctx.heated_zones, vec!["a".to_string(), "b".to_string()]);
         assert_eq!(ctx.hvac_zones, vec!["a".to_string()]);
 
@@ -335,11 +387,12 @@ mod tests {
         }
         let traj_full = ss.simulate(&x0, &u_full, dt).unwrap();
 
+        let no_loads: HashMap<String, Vec<f64>> = HashMap::new();
         for zone in &ctx.heated_zones {
             let row = ss.state_index(net.zone_indices[zone]).unwrap();
             for (k, state) in traj_full.iter().enumerate().take(n + 1).skip(1) {
                 assert_abs_diff_eq!(
-                    ctx.predict(zone, k, &heat, &air),
+                    ctx.predict(zone, k, &heat, &air, &no_loads),
                     state[row],
                     epsilon = 1e-6
                 );
@@ -347,20 +400,53 @@ mod tests {
         }
     }
 
+    /// A controllable load registered at zone "a"'s air node gets a kernel keyed by its **name**,
+    /// matching the HVAC air kernel for the same zone (it's the same air-node pulse) — and `predict`
+    /// drives the prediction with that load's signed schedule.
+    #[test]
+    fn controllable_load_kernel_matches_air_kernel_and_predicts() {
+        let (net, ss, x0, u_known, dt, n) = fixture();
+        let ctx = build_context(
+            &ss,
+            &net,
+            &x0,
+            &u_known,
+            dt,
+            &[],
+            &[("boiler".to_string(), "a".to_string())],
+        )
+        .unwrap();
+        // The load kernel onto its own zone equals the air-node kernel for that zone (same 1 kW pulse).
+        let load_k = &ctx.load_kernels[&("a".to_string(), "boiler".to_string())];
+        let air_ctx = build_context(&ss, &net, &x0, &u_known, dt, &["a".to_string()], &[]).unwrap();
+        let air_k = &air_ctx.air_kernels[&("a".to_string(), "a".to_string())];
+        for (lk, ak) in load_k.iter().zip(air_k) {
+            assert_abs_diff_eq!(lk, ak, epsilon = 1e-12);
+        }
+        // A positive (source) load raises the zone; a negative (sink) one lowers it below free.
+        let no_heat: HashMap<String, Vec<f64>> = HashMap::new();
+        let no_air: HashMap<String, Vec<f64>> = HashMap::new();
+        let on: HashMap<String, Vec<f64>> = HashMap::from([("boiler".to_string(), vec![2.0; n])]);
+        let off: HashMap<String, Vec<f64>> = HashMap::from([("boiler".to_string(), vec![-2.0; n])]);
+        assert!(ctx.predict("a", n, &no_heat, &no_air, &on) > ctx.free_response["a"][n - 1]);
+        assert!(ctx.predict("a", n, &no_heat, &no_air, &off) < ctx.free_response["a"][n - 1]);
+    }
+
     #[test]
     fn zero_heating_equals_free_response() {
         let (net, ss, x0, u_known, dt, n) = fixture();
-        let ctx = build_context(&ss, &net, &x0, &u_known, dt, &[]).unwrap();
+        let ctx = build_context(&ss, &net, &x0, &u_known, dt, &[], &[]).unwrap();
         let zero: HashMap<String, Vec<f64>> = ctx
             .heated_zones
             .iter()
             .map(|z| (z.clone(), vec![0.0; n]))
             .collect();
         let no_air: HashMap<String, Vec<f64>> = HashMap::new();
+        let no_loads: HashMap<String, Vec<f64>> = HashMap::new();
         for zone in &ctx.heated_zones {
             for k in 1..=n {
                 assert_abs_diff_eq!(
-                    ctx.predict(zone, k, &zero, &no_air),
+                    ctx.predict(zone, k, &zero, &no_air, &no_loads),
                     ctx.free_response[zone][k - 1],
                     epsilon = 1e-12
                 );
@@ -371,7 +457,7 @@ mod tests {
     #[test]
     fn heating_kernels_are_nonnegative_and_warm_the_zone() {
         let (net, ss, x0, u_known, dt, _n) = fixture();
-        let ctx = build_context(&ss, &net, &x0, &u_known, dt, &[]).unwrap();
+        let ctx = build_context(&ss, &net, &x0, &u_known, dt, &[], &[]).unwrap();
         for ((_target, _source), kernel) in &ctx.kernels {
             // Heating never cools any zone (within numerical noise).
             assert!(kernel.iter().all(|&v| v >= -1e-9));
@@ -384,7 +470,7 @@ mod tests {
     #[test]
     fn air_kernel_is_fast_and_cools_with_negative_power() {
         let (net, ss, x0, u_known, dt, n) = fixture();
-        let ctx = build_context(&ss, &net, &x0, &u_known, dt, &["a".to_string()]).unwrap();
+        let ctx = build_context(&ss, &net, &x0, &u_known, dt, &["a".to_string()], &[]).unwrap();
         // The HVAC zone gets an air-node kernel; +1 kW warms its own air immediately.
         let air = &ctx.air_kernels[&("a".to_string(), "a".to_string())];
         assert!(air.iter().all(|&v| v >= -1e-9));
@@ -399,7 +485,8 @@ mod tests {
         );
         // A cooling decision (negative air power) drives the prediction below the free response.
         let no_heat: HashMap<String, Vec<f64>> = HashMap::new();
+        let no_loads: HashMap<String, Vec<f64>> = HashMap::new();
         let cool: HashMap<String, Vec<f64>> = HashMap::from([("a".to_string(), vec![-1.0; n])]);
-        assert!(ctx.predict("a", n, &no_heat, &cool) < ctx.free_response["a"][n - 1]);
+        assert!(ctx.predict("a", n, &no_heat, &cool, &no_loads) < ctx.free_response["a"][n - 1]);
     }
 }

--- a/src/optimize/unified.rs
+++ b/src/optimize/unified.rs
@@ -37,6 +37,30 @@ const EV_SHORTFALL_PENALTY: f64 = 100.0;
 /// A tiny bias (price-units per kWh) toward solar over grid for the `solar_preferred` strategy —
 /// below any real tariff spread, so it only breaks ties the economics leave open.
 const EV_SOLAR_PREFERENCE: f64 = 0.001;
+/// Penalty (price-units per kWh) on a controllable load's run-time still missing within its window —
+/// large enough to dominate price arbitrage so the `run_hours` target is met whenever the window
+/// allows, but soft so the problem never goes infeasible (a window too short just runs as much as it
+/// can). Mirrors [`EV_SHORTFALL_PENALTY`].
+const LOAD_SHORTFALL_PENALTY: f64 = 100.0;
+
+/// One controllable (deferrable) scheduled load's inputs to the LP — a boiler / hot-water tank the
+/// optimizer switches on/off within its window to run for `run_hours` at the cheapest blocks. Built
+/// from a `controllable` [`crate::optimize::config::ScheduledLoad`].
+#[derive(Debug, Clone)]
+pub struct ControllableLoadSpec {
+    /// Stable identifier (the load's label, or its zone) — the schedule key and the kernel key.
+    pub name: String,
+    /// The zone whose air node the load's heat couples into.
+    pub zone: String,
+    /// Rated electrical draw when on (kW) — added to the house load and priced at the import tariff.
+    pub rated_kw: f64,
+    /// Signed air-node heat when on (kW): `+` for a source (warms the room), `−` for a sink (cools it).
+    pub heat_kw: f64,
+    /// Per-block: is the load inside one of its windows (allowed to run)? Out-of-window ⇒ forced off.
+    pub window: Vec<bool>,
+    /// Total run time required within the window (hours) — the soft target.
+    pub run_hours: f64,
+}
 
 /// One controllable EV charger's per-block inputs to the LP. `monitored` chargers carry no decision
 /// and are folded into `DispatchInputs::load_kw` upstream, so they never appear here.
@@ -94,6 +118,10 @@ pub struct UnifiedPlan {
     pub ev_solar_kw: HashMap<String, Vec<f64>>,
     pub ev_grid_kw: HashMap<String, Vec<f64>>,
     pub ev_batt_kw: HashMap<String, Vec<f64>>,
+    /// Per controllable load: its draw (kW) per block when on (`on · rated_kw`, so 0 when off). Keyed
+    /// by the load name; empty when none are configured. The load-shift schedule the boiler controller
+    /// reads.
+    pub controllable_load_kw: HashMap<String, Vec<f64>>,
     /// Total electricity cost over the horizon (grid import minus export; includes heating + EV).
     pub total_cost: f64,
 }
@@ -131,7 +159,7 @@ impl FlowParams {
 /// `outdoor_temp_c` is the per-block outdoor-air forecast (°C), used to evaluate each HVAC unit's
 /// COP curve per block; because it is a *known* input the per-block COP is a constant, so the
 /// problem stays a (mixed-integer) linear program.
-#[allow(clippy::too_many_arguments)] // battery / heating / hvac / thermal / inputs / flow / temps are distinct
+#[allow(clippy::too_many_arguments)] // battery / heating / hvac / thermal / inputs / flow / temps / loads are distinct
 pub fn optimize_unified(
     battery: &BatterySpec,
     heating: &HeatingConfig,
@@ -141,6 +169,7 @@ pub fn optimize_unified(
     flow: &FlowParams,
     outdoor_temp_c: &[f64],
     ev: &[EvSpec],
+    loads: &[ControllableLoadSpec],
 ) -> Result<UnifiedPlan> {
     battery.validate()?;
     inputs.validate()?;
@@ -152,6 +181,14 @@ pub fn optimize_unified(
             "EV charger {:?}: plugged window length ({}) must match the horizon ({n})",
             e.name,
             e.plugged.len()
+        );
+    }
+    for l in loads {
+        ensure!(
+            l.window.len() == n,
+            "controllable load {:?}: window length ({}) must match the horizon ({n})",
+            l.name,
+            l.window.len()
         );
     }
     ensure!(
@@ -190,7 +227,9 @@ pub fn optimize_unified(
         .filter(|z| hvac.comfort.contains_key(*z) && thermal.free_response.contains_key(*z))
         .cloned()
         .collect();
-    // Controlled zones = the union (each gets a soft comfort band), in deterministic order.
+    // Controlled zones = heated ∪ HVAC (each gets a soft comfort band), in deterministic order. A
+    // controllable load's zone is NOT here unless it is also heated/HVAC — the load is scheduled for
+    // its run-hours, not to hold a comfort band of its own (a load-only zone has no band to hold).
     let mut controlled: Vec<String> = heat_zones
         .iter()
         .chain(hvac_zones.iter())
@@ -198,6 +237,17 @@ pub fn optimize_unified(
         .collect();
     controlled.sort();
     controlled.dedup();
+    // Zones whose air temperature we report: the controlled zones plus any controllable-load zone with
+    // a thermal state row (so its load's effect on the room is visible even with no comfort actuator).
+    let mut predicted: Vec<String> = controlled.clone();
+    predicted.extend(
+        loads
+            .iter()
+            .map(|l| l.zone.clone())
+            .filter(|z| thermal.free_response.contains_key(z)),
+    );
+    predicted.sort();
+    predicted.dedup();
     let is_heat = |z: &str| heat_zones.iter().any(|h| h == z);
     let is_hvac = |z: &str| hvac_zones.iter().any(|h| h == z);
     // Per-zone comfort band: heat below the lower edge, cool above the upper. A heated zone uses
@@ -421,6 +471,31 @@ pub fn optimize_unified(
         })
         .collect();
     let ev_shortfall: Vec<Variable> = ev.iter().map(|_| vars.add(variable().min(0.0))).collect();
+
+    // Controllable loads: a per-block on/off relay (a true binary in-window, forced to 0 out-of-window)
+    // — the boiler runs at its rated power or not at all. Binary across the whole horizon (not just the
+    // near-term) so the cheapest-blocks load-shift is an integral schedule rather than a fractional one;
+    // there are few such loads, so the extra binaries stay cheap. A soft `run_hours` target uses a
+    // `shortfall` slack, mirroring the EV deadline.
+    let load_on: Vec<Vec<Variable>> = loads
+        .iter()
+        .map(|l| {
+            (0..n)
+                .map(|i| {
+                    if l.window[i] {
+                        vars.add(variable().binary())
+                    } else {
+                        vars.add(variable().min(0.0).max(0.0)) // out-of-window ⇒ forced off
+                    }
+                })
+                .collect()
+        })
+        .collect();
+    let load_shortfall: Vec<Variable> = loads
+        .iter()
+        .map(|_| vars.add(variable().min(0.0)))
+        .collect();
+
     let ev_solar_sum =
         |i: usize| -> Expression { ev_solar.iter().map(|c| Expression::from(c[i])).sum() };
     let ev_grid_sum =
@@ -468,6 +543,10 @@ pub fn optimize_unified(
             }
         }
     }
+    // Controllable loads: a large penalty on run-time still missing within the window (soft target).
+    for &slack in &load_shortfall {
+        objective += LOAD_SHORTFALL_PENALTY * slack;
+    }
     for z in &controlled {
         let pen = penalty(z);
         for k in 0..n {
@@ -499,6 +578,12 @@ pub fn optimize_unified(
                 .map(|z| Expression::from(air_heat[z][i]))
                 .sum();
             flexible_elec += cool_sum * (1.0 / cool_cop) + heat_sum * (1.0 / heat_cop);
+        }
+        // Each controllable load draws its rated power when on — a flexible electrical load met from
+        // solar/battery/grid like the heat-pump electricity, so it is priced at the import tariff and
+        // the optimizer shifts it to the cheapest in-window blocks.
+        for (c, l) in loads.iter().enumerate() {
+            flexible_elec += l.rated_kw * load_on[c][i];
         }
         // Solar is split across house, battery, grid, the EV legs and curtailment.
         problem = problem.with(constraint!(
@@ -578,6 +663,15 @@ pub fn optimize_unified(
                     }
                 }
             }
+            // Each controllable load: its signed per-kW heat, through the air-node kernel keyed by the
+            // load name, applied in the blocks it runs (`on=1`). This is the heat-when-on coupling.
+            for (c, l) in loads.iter().enumerate() {
+                if let Some(kernel) = thermal.load_kernels.get(&(z.clone(), l.name.clone())) {
+                    for j in 0..k {
+                        t_pred += kernel[k - j - 1] * l.heat_kw * load_on[c][j];
+                    }
+                }
+            }
             problem = problem.with(constraint!(t_pred.clone() + slack_lo[z][k - 1] >= lo_k));
             problem = problem.with(constraint!(t_pred - slack_hi[z][k - 1] <= hi_k));
         }
@@ -623,6 +717,14 @@ pub fn optimize_unified(
         ));
     }
 
+    // Controllable loads: the soft run-hours target — total on-time (Σ on·dt) plus a shortfall slack
+    // must reach `run_hours`. Out-of-window blocks are forced off, so the load can only accumulate
+    // run-time inside its window; if the window is too short the shortfall absorbs the gap.
+    for (c, l) in loads.iter().enumerate() {
+        let run: Expression = (0..n).map(|i| Expression::from(load_on[c][i]) * dt).sum();
+        problem = problem.with(constraint!(run + load_shortfall[c] >= l.run_hours));
+    }
+
     let solution = problem.solve()?;
 
     let values =
@@ -655,11 +757,34 @@ pub fn optimize_unified(
             )
         })
         .collect();
-    let zone_temp_c: HashMap<String, Vec<f64>> = controlled
+    // Controllable loads: the per-block draw (`on · rated_kw`) reported in the plan, and the signed
+    // heat schedule (`on · heat_kw`, keyed by name) fed to `predict` for the temperature it produced.
+    let on_value = |c: usize| -> Vec<f64> {
+        (0..n)
+            .map(|i| solution.value(load_on[c][i]).clamp(0.0, 1.0))
+            .collect()
+    };
+    let controllable_load_kw: HashMap<String, Vec<f64>> = loads
+        .iter()
+        .enumerate()
+        .map(|(c, l)| {
+            let on = on_value(c);
+            (l.name.clone(), on.iter().map(|&o| o * l.rated_kw).collect())
+        })
+        .collect();
+    let load_heat_net: HashMap<String, Vec<f64>> = loads
+        .iter()
+        .enumerate()
+        .map(|(c, l)| {
+            let on = on_value(c);
+            (l.name.clone(), on.iter().map(|&o| o * l.heat_kw).collect())
+        })
+        .collect();
+    let zone_temp_c: HashMap<String, Vec<f64>> = predicted
         .iter()
         .map(|z| {
             let temps = (1..=n)
-                .map(|k| thermal.predict(z, k, &heat_kw, &air_net) - KELVIN_OFFSET)
+                .map(|k| thermal.predict(z, k, &heat_kw, &air_net, &load_heat_net) - KELVIN_OFFSET)
                 .collect();
             (z.clone(), temps)
         })
@@ -716,6 +841,7 @@ pub fn optimize_unified(
         ev_solar_kw: ev_legs(&ev_solar),
         ev_grid_kw: ev_legs(&ev_grid),
         ev_batt_kw: ev_legs(&ev_batt),
+        controllable_load_kw,
         total_cost: grid_cash.eval_with(&solution),
     })
 }
@@ -797,7 +923,7 @@ mod tests {
             ss.n_states(),
             ThermodynamicTemperature::new::<degree_celsius>(x0_c).get::<kelvin>(),
         );
-        build_context(&ss, &net, &x0, &vec![u0; n], dt, hvac_zones).unwrap()
+        build_context(&ss, &net, &x0, &vec![u0; n], dt, hvac_zones, &[]).unwrap()
     }
 
     fn no_battery() -> BatterySpec {
@@ -875,6 +1001,7 @@ mod tests {
             inputs,
             &FlowParams::permissive(n),
             &vec![20.0; n],
+            &[],
             &[],
         )
         .unwrap()
@@ -1039,6 +1166,7 @@ mod tests {
             &flow,
             &vec![20.0; n],
             &[],
+            &[],
         )
         .unwrap();
         for t in 0..n {
@@ -1087,6 +1215,7 @@ mod tests {
             &FlowParams::permissive(n),
             &vec![20.0; n],
             &ev,
+            &[],
         )
         .unwrap();
         let charge = &plan.ev_charge_kw["garage"];
@@ -1134,6 +1263,7 @@ mod tests {
             &FlowParams::permissive(n),
             &vec![20.0; n],
             &[spec],
+            &[],
         )
         .unwrap();
         let charge = &plan.ev_charge_kw["garage"];
@@ -1166,6 +1296,7 @@ mod tests {
             &FlowParams::permissive(n),
             &vec![20.0; n],
             &[spec],
+            &[],
         )
         .unwrap();
         assert!(
@@ -1200,6 +1331,7 @@ mod tests {
             },
             &vec![20.0; n],
             &[],
+            &[],
         )
         .unwrap();
         let high_wear = optimize_unified(
@@ -1214,6 +1346,7 @@ mod tests {
                 f
             },
             &vec![20.0; n],
+            &[],
             &[],
         )
         .unwrap();
@@ -1248,6 +1381,7 @@ mod tests {
             &flow,
             &vec![20.0; n],
             &[],
+            &[],
         )
         .unwrap();
         assert!(
@@ -1278,6 +1412,7 @@ mod tests {
             &inputs,
             &flow,
             &vec![20.0; n],
+            &[],
             &[],
         )
         .unwrap();
@@ -1317,6 +1452,7 @@ mod tests {
             &flow,
             &vec![20.0; n],
             &[spec],
+            &[],
         )
         .unwrap();
         for t in 0..n {
@@ -1385,6 +1521,7 @@ mod tests {
             &vec![u0; n],
             dt,
             &["a".to_string(), "b".to_string()],
+            &[],
         )
         .unwrap()
     }
@@ -1411,6 +1548,7 @@ mod tests {
             &flat_inputs(0.2, n),
             &FlowParams::permissive(n),
             &vec![35.0; n],
+            &[],
             &[],
         )
         .unwrap();
@@ -1474,6 +1612,7 @@ mod tests {
             &FlowParams::permissive(n),
             &outdoor,
             &[],
+            &[],
         )
         .unwrap();
         assert!(
@@ -1536,6 +1675,7 @@ mod tests {
             &FlowParams::permissive(n),
             &vec![35.0; n],
             &[],
+            &[],
         )
         .unwrap();
         let mut peak = 0.0_f64;
@@ -1594,6 +1734,7 @@ mod tests {
             &flat_inputs(0.2, n),
             &FlowParams::permissive(n),
             &vec![35.0; n],
+            &[],
             &[],
         )
         .unwrap();
@@ -1660,6 +1801,7 @@ mod tests {
                 &FlowParams::permissive(n),
                 &vec![25.0; n],
                 &[],
+                &[],
             )
             .unwrap()
         };
@@ -1687,5 +1829,207 @@ mod tests {
                 "single_mode block {i}: cool={c} heat={h}"
             );
         }
+    }
+
+    /// A thermal context for zone `"a"` with a controllable load `"boiler"` registered at its air node
+    /// (the air-kernel source the LP scales by the load's on/off decision).
+    fn thermal_for_load(outside_c: f64, ground_c: f64, x0_c: f64, n: usize) -> ThermalContext {
+        let model = Model::from_json(
+            r#"{
+                materials: {
+                    air: { thermal_conductivity: 0.026, specific_heat_capacity: 1000, density: 1.2 },
+                    concrete: { thermal_conductivity: 1.5, specific_heat_capacity: 1000, density: 2000 },
+                    insulation: { thermal_conductivity: 0.04, specific_heat_capacity: 1000, density: 30 },
+                },
+                boundary_types: {
+                    floor: { layers: [
+                        { material: "concrete", thickness: 0.05 },
+                        { marker: "heating" },
+                        { material: "concrete", thickness: 0.05 },
+                    ] },
+                    wall: { layers: [
+                        { material: "concrete", thickness: 0.1 },
+                        { material: "insulation", thickness: 0.12 },
+                    ] },
+                },
+                zones: { a: { volume: 40 } },
+                boundaries: [
+                    { boundary_type: "floor", zones: ["a", "ground"], area: 16 },
+                    { boundary_type: "wall",  zones: ["a", "outside"], area: 25 },
+                ],
+            }"#,
+        )
+        .unwrap();
+        let net: RcNetwork = (&model).into();
+        let ss: StateSpace = (&net).into();
+        let dt = 3600.0;
+        let mut u0 = ss.zero_input();
+        ss.set_boundary_temp(
+            &mut u0,
+            net.zone_indices["outside"],
+            ThermodynamicTemperature::new::<degree_celsius>(outside_c),
+        );
+        ss.set_boundary_temp(
+            &mut u0,
+            net.zone_indices["ground"],
+            ThermodynamicTemperature::new::<degree_celsius>(ground_c),
+        );
+        let x0 = DVector::from_element(
+            ss.n_states(),
+            ThermodynamicTemperature::new::<degree_celsius>(x0_c).get::<kelvin>(),
+        );
+        build_context(
+            &ss,
+            &net,
+            &x0,
+            &vec![u0; n],
+            dt,
+            &[],
+            &[("boiler".to_string(), "a".to_string())],
+        )
+        .unwrap()
+    }
+
+    /// A controllable load spec for `"boiler"` in zone `"a"`: rated draw, signed heat, a window mask,
+    /// and a run-hours target.
+    fn load_spec(
+        rated_kw: f64,
+        heat_kw: f64,
+        window: Vec<bool>,
+        run_hours: f64,
+    ) -> ControllableLoadSpec {
+        ControllableLoadSpec {
+            name: "boiler".to_string(),
+            zone: "a".to_string(),
+            rated_kw,
+            heat_kw,
+            window,
+            run_hours,
+        }
+    }
+
+    fn solve_with_loads(
+        thermal: &ThermalContext,
+        inputs: &DispatchInputs,
+        loads: &[ControllableLoadSpec],
+    ) -> UnifiedPlan {
+        let n = inputs.import_price.len();
+        optimize_unified(
+            &no_battery(),
+            &no_heating(),
+            &HvacConfig::default(),
+            thermal,
+            inputs,
+            &FlowParams::permissive(n),
+            &vec![20.0; n],
+            &[],
+            loads,
+        )
+        .unwrap()
+    }
+
+    /// KEYSTONE: a controllable load with `run_hours = N` against a cheap-vs-expensive price curve is
+    /// scheduled into the **cheapest N hours within its window**, and never outside the window.
+    #[test]
+    fn controllable_load_runs_cheapest_hours_in_window() {
+        let n = 8;
+        // Inert thermal (warm zone, wide band) so only price drives the schedule.
+        let thermal = thermal_for_load(20.0, 18.0, 20.0, n);
+        let mut inputs = flat_inputs(0.20, n);
+        // A distinct price per block; the three cheapest in-window blocks are 2, 5, 6 below.
+        inputs.import_price = vec![0.90, 0.90, 0.10, 0.90, 0.90, 0.12, 0.15, 0.90];
+        // Window covers blocks 1..=6 (so block 0 and 7 are out-of-window, even if cheap-ish).
+        let window: Vec<bool> = (0..n).map(|i| (1..=6).contains(&i)).collect();
+        // Source load (sign +) but tiny heat so it doesn't perturb the (wide-band) comfort.
+        let load = load_spec(2.0, 0.0, window.clone(), 3.0); // 3 run-hours
+        let plan = solve_with_loads(&thermal, &inputs, &[load]);
+        let draw = &plan.controllable_load_kw["boiler"];
+
+        // Exactly 3 hours on (dt = 1 h), each at the rated 2 kW; 0 elsewhere.
+        let on: Vec<usize> = (0..n).filter(|&i| draw[i] > 1e-6).collect();
+        assert_eq!(
+            on,
+            vec![2, 5, 6],
+            "should run the cheapest in-window blocks: {draw:?}"
+        );
+        for &i in &on {
+            assert!((draw[i] - 2.0).abs() < 1e-6, "rated draw when on: {draw:?}");
+        }
+        // Never outside the window (block 0 and 7 must stay off even though 0 is mid-priced).
+        assert!(
+            draw[0] < 1e-6 && draw[7] < 1e-6,
+            "never runs outside the window: {draw:?}"
+        );
+        // The run-hours target is met, so the import cost is the 3 cheapest in-window prices × 2 kWh.
+        let expected = (0.10 + 0.12 + 0.15) * 2.0;
+        assert!(
+            (plan.total_cost - expected).abs() < 1e-6,
+            "cost {} vs {expected}",
+            plan.total_cost
+        );
+    }
+
+    /// `controllable: false` ⇒ no `ControllableLoadSpec` reaches the optimizer, so the plan is exactly
+    /// the passive path (empty `loads`). The two solves are byte-identical here.
+    #[test]
+    fn no_controllable_load_is_identical_to_passive() {
+        let n = 6;
+        let thermal = thermal_for(20.0, 18.0, 20.0, n); // inert, no load source
+        let mut inputs = flat_inputs(0.20, n);
+        inputs.import_price = vec![0.30, 0.10, 0.30, 0.10, 0.30, 0.10];
+        inputs.load_kw = vec![1.0; n];
+
+        let passive = solve_with_loads(&thermal, &inputs, &[]);
+        let also_passive = solve_with_loads(&thermal, &inputs, &[]);
+        assert_eq!(passive.total_cost, also_passive.total_cost);
+        assert_eq!(passive.grid_import_kw, also_passive.grid_import_kw);
+        assert!(
+            passive.controllable_load_kw.is_empty(),
+            "no controllable load ⇒ empty schedule map"
+        );
+    }
+
+    /// Heat-when-on couples: a controllable **sink** (negative heat) lowers the predicted zone
+    /// temperature only in the blocks it runs, leaving the off-blocks at the free response.
+    #[test]
+    fn controllable_sink_cools_only_on_blocks() {
+        let n = 6;
+        // Warm zone with a wide comfort band so the sink never trips the (penalized) comfort floor —
+        // its only effect on the prediction is the air-node cooling in the on-blocks.
+        let thermal = thermal_for_load(24.0, 22.0, 24.0, n);
+        let inputs = flat_inputs(0.20, n);
+        // Force a deterministic single on-block: run_hours = 1 h with a window of only block 3.
+        let window: Vec<bool> = (0..n).map(|i| i == 3).collect();
+        // A sink: 2 kW rated draw, −1.5 kW air heat (cools the room while on).
+        let load = load_spec(2.0, -1.5, window, 1.0);
+        let plan = solve_with_loads(&thermal, &inputs, &[load]);
+        let draw = &plan.controllable_load_kw["boiler"];
+        assert!(draw[3] > 1e-6, "the single in-window block runs: {draw:?}");
+        assert!(
+            (0..n).filter(|&i| i != 3).all(|i| draw[i] < 1e-6),
+            "off everywhere but block 3: {draw:?}"
+        );
+
+        // The free response (no load) is the baseline (°C): with no load the prediction equals it.
+        // The on-block prediction must dip below it, and the blocks before the load runs are unchanged.
+        let with = &plan.zone_temp_c["a"];
+        let free_c: Vec<f64> = thermal.free_response["a"]
+            .iter()
+            .map(|k| k - KELVIN_OFFSET)
+            .collect();
+        // Step index k-1 = 2 is the end of block 2 (before the load runs in block 3); unchanged.
+        assert!(
+            (with[2] - free_c[2]).abs() < 1e-9,
+            "no effect before it runs"
+        );
+        // From the on-block onward the sink has cooled the zone.
+        assert!(
+            with[3] < free_c[3] - 1e-6,
+            "sink cools the on-block: {with:?} vs {free_c:?}"
+        );
+        assert!(
+            with[5] < free_c[5] - 1e-6,
+            "the cooling persists after: {with:?} vs {free_c:?}"
+        );
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -824,6 +824,8 @@ mod tests {
             power_w: None,
             sensor: None,
             power_factor: None,
+            controllable: false,
+            run_hours: None,
             windows: vec![LoadWindow {
                 months: Vec::new(),
                 start: "10:00".to_string(),
@@ -907,6 +909,8 @@ mod tests {
             power_w: None,
             sensor: None,
             power_factor: None,
+            controllable: false,
+            run_hours: None,
             windows: vec![LoadWindow {
                 months: Vec::new(),
                 start: "10:00".to_string(),
@@ -986,6 +990,8 @@ mod tests {
             power_w: Some(FIXED_SINK),
             sensor: None,
             power_factor: None,
+            controllable: false,
+            run_hours: None,
             windows: vec![LoadWindow {
                 months: Vec::new(),
                 start: "10:00".to_string(),
@@ -1082,6 +1088,8 @@ mod tests {
             power_w: None,
             sensor: Some(sensor_locator()),
             power_factor: Some(2.0),
+            controllable: false,
+            run_hours: None,
             windows: vec![LoadWindow {
                 months: vec![6, 7, 8],
                 start: "10:00".to_string(),
@@ -1160,6 +1168,8 @@ mod tests {
             power_w: None,
             sensor: Some(sensor_locator()),
             power_factor: Some(1.0),
+            controllable: false,
+            run_hours: None,
             windows: vec![LoadWindow {
                 months: Vec::new(),
                 start: "10:00".to_string(),

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -252,11 +252,45 @@ fn nnls(a: &[Vec<f64>], b: &[f64], cols: usize) -> Vec<f64> {
     x
 }
 
+/// Per scheduled load with a `sensor`, its **measured** electrical-power series (W) forward-filled
+/// onto the hourly grid (`None` for a load with no sensor), aligned 1:1 to `scheduled_loads`. The drive
+/// derives a sensor-driven load's flux from this (× `power_factor`, gated by the schedule) instead of a
+/// fitted/configured magnitude. Mirrors [`read_heating_kw`]'s read → `resample_ffill` alignment; a
+/// sensor whose read fails or returns nothing degrades to `None` (the magnitude path applies).
+async fn read_sensor_power_w(
+    db: &SourceClients,
+    scheduled_loads: &[ScheduledLoad],
+    hours: &[i64],
+    start: &str,
+    stop: &str,
+) -> Vec<Option<Vec<f64>>> {
+    let mut out = Vec::with_capacity(scheduled_loads.len());
+    for load in scheduled_loads {
+        let series = match &load.sensor {
+            Some(loc) => match db.read_locator_series(loc, start, stop, "1h").await {
+                Ok(s) if !s.is_empty() => Some(resample_ffill(hours, &s)),
+                Ok(_) => None,
+                Err(e) => {
+                    eprintln!(
+                        "  load_active: scheduled load '{}' sensor read failed ({e}), falling back to magnitude",
+                        load.label
+                    );
+                    None
+                }
+            },
+            None => None,
+        };
+        out.push(series);
+    }
+    out
+}
+
 /// Read everything an active (heating-on) fit/backtest needs over `[start, stop]`: the driving data
 /// (outside temp + cloud), the **recorded per-zone heating relays**, the measured seed state, and the
 /// measured per-zone temperature series. The returned `DriveData` carries the scheduled loads with
 /// their **fixed** (`power_w`) magnitudes applied and the fitted ones at 0 (the probe driver in
-/// [`fit_gains`] sets those), plus the site `local_offset`, but **no** internal gains.
+/// [`fit_gains`] sets those), each sensor-driven load's **measured** power series, plus the site
+/// `local_offset`, but **no** internal gains.
 #[allow(clippy::too_many_arguments)] // db, model, heating, loads, offset, cfg and time bounds are all distinct
 async fn load_active(
     db: &SourceClients,
@@ -280,6 +314,8 @@ async fn load_active(
         .iter()
         .map(|l| l.power_w.unwrap_or(0.0))
         .collect();
+    // Sensor-driven loads derive their flux from the measured draw, read here onto the same hourly grid.
+    data.sensor_power_w = read_sensor_power_w(db, scheduled_loads, &data.hours, start, stop).await;
     data.local_offset = local_offset;
     let (x0, zone_series) = seed_state(db, net, ss, start, stop).await?;
     Ok((data, x0, zone_series))
@@ -307,8 +343,10 @@ pub struct GainFit {
 /// baseline; probe each *cold* zone (negative mean residual) with a unit internal gain and each
 /// **fitted** scheduled load with a unit magnitude to measure their full (coupled) response (one
 /// column each); then solve `column·c = target` with non-negative least squares. A **fixed** load
-/// (`power_w` set) is a known input, not a candidate: it's applied at its configured magnitude in the
-/// baseline drive *and* every probe, so the fit explains only what's left over it. Fitting zones
+/// (`power_w` set) or a **sensor**-driven load (flux from the measured draw) is a known input, not a
+/// candidate: it's applied at its configured/measured magnitude in the baseline drive *and* every
+/// probe (the latter via `data`'s `sensor_power_w`), so the fit explains only what's left over it.
+/// Fitting zones
 /// independently would overheat small rooms via their big neighbours' leakage through shared walls;
 /// the joint fit doesn't. `data` must carry the recorded heating, **no** internal gains, and the
 /// loads' `zone`/`local_offset`; its `scheduled_w` is ignored — the baseline and every probe rebuild
@@ -441,14 +479,15 @@ fn fit_gains(
     }
     let n_gain_cands = gain_zones.len();
 
-    // One candidate per **fitted** scheduled load (`power_w` None) whose zone is in the model. A
-    // **fixed** load is a known input already applied in `fixed_w`, never a candidate. Probe by adding
-    // the unit magnitude to that load's slot (on top of the fixed magnitudes) and reading its coupled
-    // response.
+    // One candidate per **fitted** scheduled load (`power_w` None and no `sensor`) whose zone is in the
+    // model. A **fixed** load (`power_w`) is a known input already applied in `fixed_w`; a
+    // **sensor-driven** load is also known — its measured flux is already in the baseline/probes via
+    // `data.sensor_power_w` in the drive — so neither is a candidate. Probe a fitted load by adding the
+    // unit magnitude to its slot (on top of the fixed magnitudes) and reading its coupled response.
     let mut load_cand_idx: Vec<usize> = Vec::new(); // index into `scheduled_loads`
     for (li, load) in scheduled_loads.iter().enumerate() {
-        if load.power_w.is_some() {
-            continue; // known magnitude — applied, not fitted
+        if load.power_w.is_some() || load.sensor.is_some() {
+            continue; // known magnitude (configured) or measured (sensor) — applied, not fitted
         }
         if !net.zone_indices.contains_key(&load.zone) {
             continue;
@@ -761,6 +800,7 @@ mod tests {
             internal_gain_w: HashMap::new(),
             scheduled_loads: loads.to_vec(),
             scheduled_w: vec![0.0; loads.len()],
+            sensor_power_w: vec![None; loads.len()],
             local_offset,
         }
     }
@@ -782,6 +822,8 @@ mod tests {
             label: "water heat-pump".to_string(),
             kind: LoadKind::Sink,
             power_w: None,
+            sensor: None,
+            power_factor: None,
             windows: vec![LoadWindow {
                 months: Vec::new(),
                 start: "10:00".to_string(),
@@ -863,6 +905,8 @@ mod tests {
             label: "water heat-pump".to_string(),
             kind: LoadKind::Sink,
             power_w: None,
+            sensor: None,
+            power_factor: None,
             windows: vec![LoadWindow {
                 months: Vec::new(),
                 start: "10:00".to_string(),
@@ -940,6 +984,8 @@ mod tests {
             label: "water heat-pump".to_string(),
             kind: LoadKind::Sink,
             power_w: Some(FIXED_SINK),
+            sensor: None,
+            power_factor: None,
             windows: vec![LoadWindow {
                 months: Vec::new(),
                 start: "10:00".to_string(),
@@ -998,6 +1044,178 @@ mod tests {
         assert!(
             gain_err < 0.1,
             "recovered gain {gain:.1} W (true {TRUE_GAIN}) with the fixed sink held"
+        );
+    }
+
+    /// A locator literal for a sensor-driven scheduled load (the actual backend is never read in these
+    /// pure-drive tests — the measured series is injected into `DriveData.sensor_power_w` directly).
+    fn sensor_locator() -> crate::source::SourceLocator {
+        json5::from_str(
+            r#"{ type: "influx", bucket: "loxone", measurement: "power", field: "hp_w" }"#,
+        )
+        .unwrap()
+    }
+
+    /// `drive` derives a sensor-driven load's flux from the **measured** power series:
+    /// `kind_sign × P_elec[h] × power_factor`, still gated by the window/months — never from
+    /// `scheduled_w`. The check: a sensor sink with constant draw `P` and factor `k` produces the same
+    /// trajectory as a plain fitted sink at magnitude `P·k`; and outside its months the flux is 0
+    /// (identical to a free-response drive with the load off).
+    #[test]
+    fn drive_uses_measured_sensor_power_times_factor() {
+        let (net, ss) = one_zone();
+        let local_offset = FixedOffset::east_opt(0).unwrap();
+        let (lat, lon) = (Angle::new::<degree>(50.0), Angle::new::<degree>(14.0));
+        let x0 = DVector::from_element(
+            ss.n_states(),
+            ThermodynamicTemperature::new::<degree_celsius>(20.0)
+                .get::<uom::si::thermodynamic_temperature::kelvin>(),
+        );
+        let state_row = ss.state_index(net.zone_indices["lr"]).unwrap();
+        let n_hours = 24 * 3;
+
+        // A daytime sink in `lr`, active 10:00–14:00 only in summer months (June–August).
+        let sensor_load = ScheduledLoad {
+            zone: "lr".to_string(),
+            label: "water heat-pump".to_string(),
+            kind: LoadKind::Sink,
+            power_w: None,
+            sensor: Some(sensor_locator()),
+            power_factor: Some(2.0),
+            windows: vec![LoadWindow {
+                months: vec![6, 7, 8],
+                start: "10:00".to_string(),
+                end: "14:00".to_string(),
+            }],
+        };
+
+        // Drive A: the sensor load with a constant measured draw of 400 W (× factor 2.0 ⇒ 800 W flux).
+        const P_ELEC: f64 = 400.0;
+        const FACTOR: f64 = 2.0;
+        let mut data_sensor = synthetic_drive(
+            0,
+            n_hours,
+            8.0,
+            std::slice::from_ref(&sensor_load),
+            local_offset,
+        );
+        data_sensor.sensor_power_w = vec![Some(vec![P_ELEC; n_hours])];
+        let traj_sensor = drive(&net, &ss, lat, lon, &x0, &data_sensor);
+
+        // Drive B: the SAME load as a plain fitted sink (no sensor) at magnitude P·factor = 800 W.
+        let plain_load = ScheduledLoad {
+            sensor: None,
+            power_factor: None,
+            ..sensor_load.clone()
+        };
+        let mut data_plain = synthetic_drive(0, n_hours, 8.0, &[plain_load], local_offset);
+        data_plain.scheduled_w = vec![P_ELEC * FACTOR];
+        let traj_plain = drive(&net, &ss, lat, lon, &x0, &data_plain);
+
+        // The two trajectories must coincide: the measured-power path equals the magnitude path.
+        for (a, b) in traj_sensor.iter().zip(&traj_plain) {
+            assert!(
+                (a[state_row] - b[state_row]).abs() < 1e-9,
+                "sensor flux (P·factor) must equal the magnitude path"
+            );
+        }
+
+        // grid hour 0 is unix-epoch (1970-01-01, a January = out of the June–August months), so the load
+        // is inactive: the sensor trajectory must equal the free response (the load contributes nothing).
+        let mut data_off = synthetic_drive(0, n_hours, 8.0, &[sensor_load], local_offset);
+        data_off.sensor_power_w = vec![Some(vec![P_ELEC; n_hours])];
+        let traj_off = drive(&net, &ss, lat, lon, &x0, &data_off);
+        let mut data_free = synthetic_drive(0, n_hours, 8.0, &[], local_offset);
+        data_free.sensor_power_w = Vec::new();
+        let traj_free = drive(&net, &ss, lat, lon, &x0, &data_free);
+        for (a, b) in traj_off.iter().zip(&traj_free) {
+            assert!(
+                (a[state_row] - b[state_row]).abs() < 1e-9,
+                "outside its months a sensor load must contribute zero flux"
+            );
+        }
+    }
+
+    /// A sensor-driven load is a KNOWN input, not a fit candidate: `fit_gains` must not invent a
+    /// magnitude for it (its `scheduled_w` slot stays at the seed). The measured flux is already in the
+    /// baseline via the drive, so the fit explains only what's left — here, an unknown constant gain.
+    #[test]
+    fn fit_does_not_fit_a_sensor_driven_load() {
+        let (net, ss) = one_zone();
+        let local_offset = FixedOffset::east_opt(0).unwrap();
+        let (lat, lon) = (Angle::new::<degree>(50.0), Angle::new::<degree>(14.0));
+        let x0 = DVector::from_element(
+            ss.n_states(),
+            ThermodynamicTemperature::new::<degree_celsius>(20.0)
+                .get::<uom::si::thermodynamic_temperature::kelvin>(),
+        );
+        let state_row = ss.state_index(net.zone_indices["lr"]).unwrap();
+        let n_hours = 24 * 5;
+
+        // A daytime sensor-driven sink, active every day so the on/off shape is identifiable in-window.
+        let loads = [ScheduledLoad {
+            zone: "lr".to_string(),
+            label: "water heat-pump".to_string(),
+            kind: LoadKind::Sink,
+            power_w: None,
+            sensor: Some(sensor_locator()),
+            power_factor: Some(1.0),
+            windows: vec![LoadWindow {
+                months: Vec::new(),
+                start: "10:00".to_string(),
+                end: "14:00".to_string(),
+            }],
+        }];
+
+        // Truth: a 250 W always-on gain AND the measured sink (600 W draw × factor 1.0), both in `lr`.
+        const TRUE_GAIN: f64 = 250.0;
+        const SENSOR_W: f64 = 600.0;
+        let mut truth = synthetic_drive(0, n_hours, 8.0, &loads, local_offset);
+        truth.sensor_power_w = vec![Some(vec![SENSOR_W; n_hours])];
+        truth.internal_gain_w = HashMap::from([("lr".to_string(), TRUE_GAIN)]);
+        let truth_traj = drive(&net, &ss, lat, lon, &x0, &truth);
+        let zone_series: HashMap<String, Vec<TimeSample>> = HashMap::from([(
+            "lr".to_string(),
+            truth
+                .hours
+                .iter()
+                .zip(&truth_traj)
+                .map(|(&h, x)| TimeSample {
+                    time: Utc.timestamp_opt(h * 3600, 0).single().unwrap(),
+                    value: k_to_c(x[state_row]),
+                })
+                .collect(),
+        )]);
+
+        // The fit's `data` carries the same measured sensor series (as `load_active` would), the loads,
+        // and no fitted gains; `scheduled_w` for the sensor slot is irrelevant (the drive uses the
+        // measured series). The fit must recover the gain and leave the sensor slot untouched (0).
+        let mut data = synthetic_drive(0, n_hours, 8.0, &loads, local_offset);
+        data.sensor_power_w = vec![Some(vec![SENSOR_W; n_hours])];
+        let fit = fit_gains(
+            &net,
+            &ss,
+            lat,
+            lon,
+            &x0,
+            &data,
+            &zone_series,
+            &loads,
+            n_hours,
+            local_offset,
+        );
+
+        // (a) the sensor-driven load is not a candidate — its magnitude slot stays at the 0 seed.
+        assert_eq!(
+            fit.scheduled_w[0], 0.0,
+            "a sensor-driven load must not be assigned a fitted magnitude"
+        );
+        // (b) the always-on gain is still recovered (the measured sink is already in the baseline).
+        let gain = fit.gains.get("lr").copied().unwrap_or(0.0);
+        let gain_err = (gain - TRUE_GAIN).abs() / TRUE_GAIN;
+        assert!(
+            gain_err < 0.1,
+            "recovered gain {gain:.1} W (true {TRUE_GAIN}) with the measured sink held"
         );
     }
 }


### PR DESCRIPTION
Extends scheduled loads along the *appliance* direction with **two** complementary pieces — a
read-only **sensor** (monitor) and a dormant **controllable** scaffold (control). Both ship dormant;
existing configs stay byte-identical.

### 1. Measured-draw sensor (monitor)
A scheduled load can point a `sensor` (a read-only `SourceLocator` — e.g. a Loxone Smart Socket's
power in InfluxDB) at the appliance, plus a `power_factor`. When set, the calibration/backtest
derives the load's zone-heat flux from the **measured** electrical draw — `sign × P_elec ×
power_factor` (≈ COP−1 for a heat-pump sink), gated by the load's months/windows — instead of a
fitted/configured magnitude, so the calibration is grounded in the real run (robust to away weeks +
variable reheat length). The schedule + `power_w` stay the **forecast** (you can't read a future
draw).

- A sensor-driven load is a known input, **not** a fit candidate; a failed/empty read degrades
  cleanly to the magnitude path.
- Reuses `read_locator_series` — no new infrastructure. Surfaces as `source: "measured"` in
  `/api/calibration/gains`.

### 2. Controllable load-shifting (control scaffold)
A scheduled load can be marked `controllable`: instead of a fixed-schedule passive flux, the
optimizer switches it on/off within its windows to run for `run_hours` at the cheapest blocks (the
boiler / hot-water scenario), with its heat-when-on coupled into the thermal prediction. Reuses the
EV deferrable-load seam (on/off binary + soft shortfall), the HVAC air-kernel, and the generic
`Payload::Load` controller channel — no new appliance type.

- `controllable: false` (the default) leaves the plan byte-identical to the passive path.
- A new dry-run `controllers/boiler` crate consumes the `load` payload (a stub `translate` that only
  logs the would-send record — no device protocol yet). MPC stays read-only / MQTT-free (CI-enforced
  via `cargo tree`).

Reviewed via the repo's iterative multi-agent review (≥3 blind `Explore` agents) — converged, all real
findings fixed (controllable-load name-uniqueness + unmodelled-zone guard) — plus a doc/comment pass.
259 tests green, clippy/fmt clean. The boiler controller is **dormant** until the Modbus hardware
arrives (it ships dry-run behind the two-key arm).