### PR TITLE
Building model: solar absorptance, measured first floor + attic envelope

### DIFF
--- a/config.json5
+++ b/config.json5
@@ -16,31 +16,30 @@
         // "coefficient of performance" is 1.0 (no heat pump). max_heat_kw below is the electric load.
         cop: 1.0,
         comfort_penalty: 50.0,     // price-units per K per step of comfort-band violation
-        // Underfloor-heated ground-floor zones (see model.json5 `ground_level_floor`).
+        // Underfloor-heated zones, ground + first floor (see model.json5 `ground_level_floor` / `first_level_floor`).
         // internal_gain_w: constant internal heat (occupants/appliances/cooking/fireplace) the
         // physics model has no source for. Fitted by the winter active backtest (non-negative least
         // squares over Jan 2026: `backtest-heating`), which cut mean zone RMSE 1.59 K -> 0.45 K.
         // Re-fit if usage patterns change; zones omit it (= 0) where the model needs no extra heat.
         zones: {
-            entrance:        { max_heat_kw: 2.0, t_min: 19.0, t_max: 23.0 },
-            ground_closet:   { max_heat_kw: 1.5, t_min: 18.0, t_max: 23.0 },
-            technical_room:  { max_heat_kw: 1.5, t_min: 16.0, t_max: 23.0, internal_gain_w: 39 },  // boiler/equipment standby
-            ground_hall:     { max_heat_kw: 2.0, t_min: 19.0, t_max: 23.0, internal_gain_w: 56 },
-            toilet:          { max_heat_kw: 1.0, t_min: 19.0, t_max: 23.0 },
-            ground_bathroom: { max_heat_kw: 2.0, t_min: 21.0, t_max: 24.0 },
-            livingroom:      { max_heat_kw: 4.0, t_min: 20.0, t_max: 23.0, internal_gain_w: 351 }, // fireplace + occupancy
-            kitchen:         { max_heat_kw: 3.0, t_min: 20.0, t_max: 23.0, internal_gain_w: 261 }, // cooking + appliances
-            storage:         { max_heat_kw: 1.0, t_min: 16.0, t_max: 23.0, internal_gain_w: 47 },
-            office:          { max_heat_kw: 2.5, t_min: 20.0, t_max: 23.0, internal_gain_w: 15 },  // occupant + PC
-            // --- first floor (relay-heated; model.json5 floor boundaries / heating markers still TODO
-            //     → dormant in the optimizer until those land. Bands are PLACEHOLDERS — tune them.
-            first_floor_hall:     { max_heat_kw: 2.0, t_min: 19.0, t_max: 23.0 }, // ~ ground_hall
-            first_floor_bathroom: { max_heat_kw: 2.0, t_min: 21.0, t_max: 24.0 }, // ~ ground_bathroom
-            first_floor_closet:   { max_heat_kw: 1.5, t_min: 18.0, t_max: 23.0 }, // ~ ground_closet
-            bedroom:              { max_heat_kw: 2.5, t_min: 19.0, t_max: 23.0 },
-            room_1:               { max_heat_kw: 2.5, t_min: 19.0, t_max: 23.0 },
-            room_2:               { max_heat_kw: 2.5, t_min: 19.0, t_max: 23.0 },
-            guestroom:            { max_heat_kw: 3.0, t_min: 18.0, t_max: 23.0 },
+            entrance:        { max_heat_kw: 0.82, t_min: 18.0, t_max: 24.0 },  // zadveri
+            ground_closet:   { max_heat_kw: 0.82, t_min: 18.0, t_max: 25.0 },  // satna_dole
+            technical_room:  { max_heat_kw: 0.82, t_min: 18.0, t_max: 24.0, internal_gain_w: 39 },  // boiler/equipment standby
+            ground_hall:     { max_heat_kw: 1.8, t_min: 20.0, t_max: 24.0, internal_gain_w: 56 },
+            toilet:          { max_heat_kw: 0.22, t_min: 20.0, t_max: 24.0 },
+            ground_bathroom: { max_heat_kw: 0.47, t_min: 20.0, t_max: 24.0 },
+            livingroom:      { max_heat_kw: 3.0, t_min: 21.0, t_max: 24.0, internal_gain_w: 351 }, // fireplace + occupancy
+            kitchen:         { max_heat_kw: 1.8, t_min: 21.0, t_max: 24.0, internal_gain_w: 261 }, // cooking + appliances
+            storage:         { max_heat_kw: 0.46, t_min: 18.0, t_max: 25.0, internal_gain_w: 47 }, // spajz
+            office:          { max_heat_kw: 0.82, t_min: 21.0, t_max: 24.0, internal_gain_w: 15 },  // occupant + PC
+            // --- first floor ---
+            first_floor_hall:     { max_heat_kw: 1.2,  t_min: 19.0, t_max: 25.0 }, // chodba nahore (landing)
+            first_floor_bathroom: { max_heat_kw: 0.62, t_min: 20.0, t_max: 24.0 }, // bathroom
+            first_floor_closet:   { max_heat_kw: 0.56, t_min: 18.0, t_max: 25.0 }, // satna (storage)
+            bedroom:              { max_heat_kw: 1.2,  t_min: 20.0, t_max: 21.0 }, // loznice (master)
+            room_1:               { max_heat_kw: 1.2,  t_min: 21.5, t_max: 22.5 }, // pokoj 1 (children)
+            room_2:               { max_heat_kw: 1.2,  t_min: 18.0, t_max: 25.0 }, // pokoj 2 (unused)
+            guestroom:            { max_heat_kw: 2.02, t_min: 18.0, t_max: 25.0 }, // hosti (unused)
         },
     },
     // Reversible HVAC / air-conditioning (PLANNED — not yet installed). Each unit injects/removes
@@ -81,7 +80,7 @@
     tariff: {
         eur_czk_rate: 25.0,
         distribution_high_czk: 0.919,   // VT: 0.755 distribution + 0.164 system services
-        distribution_low_czk: 0.281,    // NT: 0.116 + 0.164
+        distribution_low_czk: 0.281,    // NT: 0.117 + 0.164
         low_tariff_hours: "0-10,11-12,13-14,15-17,18-24", // NT local-hour ranges (end exclusive)
         sell_fee_czk: 0.5,              // FVE buyback = OTE spot - 0.5 Kc/kWh (matches loxone)
         export_price_min_czk: 0.5,      // never export below this spot (revenue >= 0; = sell fee, matches loxone GROWATT_EXPORT_PRICE_MIN=0.5)
@@ -107,9 +106,9 @@
     // EV charger — the Loxone wallbox, detected exactly as loxone_smart_home's battery-protect logic
     // does: the `ev` measurement in the `loxone` bucket. `ev_connected` (1/0) is the authoritative
     // "on our wallbox" flag (loxone-side, so it respects "TeslaMate ≠ on our charger"); `ev_charging_power`
-    // is the live charge power in kW. Car SoC is not in InfluxDB — add a TeslaMate `soc` source (see the
-    // commented Postgres example in docs/ev.md) to unlock target-by-deadline scheduling; until then the
-    // charger is observed (status + live power) but not scheduled toward a %.
+    // is the live charge power in kW. Car SoC comes from TeslaMate's Postgres (the `soc` source below,
+    // DSN in $MPC_PG_TESLAMATE), so the charger is scheduled toward `target_pct` by `deadline` — not
+    // just observed.
     chargers: [
         {
             name: "tesla",

--- a/config.json5
+++ b/config.json5
@@ -18,9 +18,10 @@
         comfort_penalty: 50.0,     // price-units per K per step of comfort-band violation
         // Underfloor-heated zones, ground + first floor (see model.json5 `ground_level_floor` / `first_level_floor`).
         // internal_gain_w: constant internal heat (occupants/appliances/cooking/fireplace) the
-        // physics model has no source for. Fitted by the winter active backtest (non-negative least
-        // squares over Jan 2026: `backtest-heating`), which cut mean zone RMSE 1.59 K -> 0.45 K.
-        // Re-fit if usage patterns change; zones omit it (= 0) where the model needs no extra heat.
+        // physics model has no source for. The ground-floor values were fitted by the winter active
+        // backtest (non-negative least squares over Jan 2026: `backtest-heating`), which cut mean zone
+        // RMSE 1.59 K -> 0.45 K. The first-floor zones don't set it yet (= 0, not yet fitted).
+        // Re-fit if usage patterns change.
         zones: {
             entrance:        { max_heat_kw: 0.82, t_min: 18.0, t_max: 24.0 },  // zadveri
             ground_closet:   { max_heat_kw: 0.82, t_min: 18.0, t_max: 25.0 },  // satna_dole
@@ -96,6 +97,8 @@
         round_trip_efficiency: 0.85,
     },
     // PV arrays — clear-sky fallback model (Solcast already covers both arrays when available).
+    // Azimuths are the real panel bearings on the hip roof (a SW + a SE facet); they are independent
+    // of model.json5's thermal roof, which approximates the whole roof as its two main NE/SW slopes.
     pv: {
         system_efficiency: 0.85,
         arrays: [

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,8 +26,9 @@ This is the one thing to get right.
 | `zones.*.volume` | volume | **m³** |
 | `boundaries.*.area`, `sub_boundaries.*.area` | area | **m²** |
 | `boundary_types` layer `thickness` | length | **m** |
+| `boundary_types` Layered `solar_absorptance` | ratio | **dimensionless** (0–1, default 1.0) |
 | Simple boundary `u` | heat transfer | **W/(m²·K)** |
-| Simple boundary `g` | ratio | **dimensionless** (0–1) |
+| Simple boundary `g` | ratio | **dimensionless** (0–1) — *currently unused* (no solar on Simple boundaries) |
 | `boundaries.*.azimuth`, `boundaries.*.angle` | angle | ⚠️ **degrees** (raw `f64`) |
 
 > ⚠️ **The one trap:** `azimuth` and `angle` are kept as raw `f64` **degrees**, *not* `uom` angles —
@@ -55,14 +56,19 @@ A library of physical properties, referenced by name from boundary layers.
 
 ```json5
 materials: {
-  concrete:         { thermal_conductivity: 1.5,   specific_heat_capacity: 1000, density: 2000 },
-  brick_440:        { thermal_conductivity: 0.059, specific_heat_capacity: 1000, density: 850 },
-  floor_insulation: { thermal_conductivity: 0.035, specific_heat_capacity: 1450, density: 30 },
+  concrete:         { thermal_conductivity: 1.5,   specific_heat_capacity: 1020, density: 2250 },
+  brick_440:        { thermal_conductivity: 0.059, specific_heat_capacity: 1000, density: 660 },   // Heluz Family 2v1 44
+  floor_insulation: { thermal_conductivity: 0.035, specific_heat_capacity: 1270, density: 30 },
+  spray_foam:       { thermal_conductivity: 0.030, specific_heat_capacity: 1400, density: 35 },    // closed-cell PUR under the rafters
+  vencovka:         { thermal_conductivity: 0.090, specific_heat_capacity: 1000, density: 400 },   // Heluz věncovka ring-beam shell
 }
 ```
 
 `air` is **auto-supplied** (0.026 W/(m·K), 1012 J/(kg·K), 1.199 kg/m³); define it yourself only to
-override those defaults.
+override those defaults. The real `model.json5` defines ~14 materials — the Heluz brick range
+(`brick_440`/`300`/`175`/`175_accoustic`), `ext_plaster`/`int_plaster`, `floor_insulation`,
+`anhydrite`, `concrete`, `drywall`, `rock_wool`, `spray_foam`, and `vencovka` — each from a
+manufacturer datasheet; copy the pattern with your own values.
 
 ### `zones`
 
@@ -101,11 +107,21 @@ ground_level_floor: {
 - `{ marker: "name" }` places a **named node between layers** — the actuator/measurement point. The
   underfloor heating injects its power at the `"heating"` marker (see [`docs`](#hvac--air-side-heating-and-cooling)).
 - Rules: **at least one non-marker layer**, and **no two consecutive markers**.
+- **`solar_absorptance`** (optional, default `1.0`): the fraction of incident solar the outer surface
+  absorbs (0–1). A Layered boundary that touches `outside` and carries `azimuth`/`angle` becomes a
+  **solar surface**, and its absorbed flux is `irradiance × area × solar_absorptance`. Lower it for a
+  reflective or **ventilated** assembly — e.g. the `roof` type uses `0.2`, because the air gap under
+  the black tiles carries most of the absorbed heat away. Omit it (⇒ `1.0`) for a plain opaque face.
+- Beyond walls, the real `model.json5` instantiates this same Layered shape as `first_level_floor`
+  (the inter-floor slab), `venec` (the concrete + insulation ring-beam band below the ceiling), `roof`
+  (the insulated roof, carrying `solar_absorptance`), and `plaster_partition` (a single drywall layer).
 
-**Simple** — a massless element given by its U-value and solar gain (windows, doors):
+**Simple** — a massless element given by its U-value (windows, doors). **Simple boundaries get no
+solar gain** — only Layered surfaces become solar surfaces — so `g` (the solar heat-gain coefficient)
+is currently parsed but **not used** by the thermal model; it is kept for forward-compatibility:
 
 ```json5
-window:        { u: 0.74, g: 0.5 },   // U-value W/(m²·K); g = solar heat-gain coefficient (0–1)
+window:        { u: 0.74, g: 0.5 },   // U-value W/(m²·K); g (solar heat-gain coeff, 0–1) — currently unused
 entrance_door: { u: 1.2,  g: 0.0 },
 ```
 
@@ -133,7 +149,9 @@ boundaries: [
 - **`area`** in m². **`sub_boundaries`** carve smaller elements (windows, doors) out of a parent; each
   sub-area must be **≤ the parent area**, and the leftover area auto-fills with the parent type.
 - **`azimuth` / `angle`** (degrees) orient a face for **solar gain**; only exterior boundaries
-  (touching `outside`) need them. Sub-boundaries **inherit** the parent's orientation.
+  (touching `outside`) need them. Sub-boundaries **inherit** the parent's orientation. Use your
+  house's true bearings — the example house is rotated ~50° off cardinal, so its faces are
+  SE = 140°, SW = 230°, NW = 320°, NE = 50°.
 - Zero-area boundaries are skipped.
 
 ---
@@ -178,7 +196,7 @@ heating: {
 |---|---|---|
 | `cop` | — | heat / electricity |
 | `comfort_penalty` | price-units/(K·step) | soft-comfort weight |
-| `zones.*.max_heat_kw` | kW | the circuit's electric power |
+| `zones.*.max_heat_kw` | kW | the zone's underfloor circuit power (the relay rating); caps the optimizer's per-step heat for the zone |
 | `zones.*.t_min` / `t_max` | °C | comfort band edges |
 | `zones.*.internal_gain_w` | W | optional (default 0); occupants/appliances/fireplace |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,16 +90,20 @@ zones: {
 A reusable template for a wall / floor / roof / window. Two shapes (an untagged enum — chosen by which
 keys are present):
 
-**Layered** — a stack of material layers with mass. Layers are listed as the **physical stack** from
-one zone's face to the other; the model expands them into a chain of capacitive nodes.
+**Layered** — a stack of material layers with mass. Layers are listed as the **physical stack from
+`zones[0]`'s face to `zones[1]`'s face**: the first layer touches the *first* zone named in each
+boundary, the last layer the *second* (`rc_network.rs` attaches the first layer to `zones[0]`). **Get
+this direction right** — reversing it puts the mass and insulation on the wrong sides. The model expands
+the stack into a chain of capacitive nodes.
 
 ```json5
+// Ground-floor slab, listed room-side (zones[0]) → ground-side (zones[1]):
 ground_level_floor: {
   layers: [
-    { material: "concrete",         thickness: 0.20 },
-    { material: "floor_insulation", thickness: 0.14 },
-    { marker: "heating" },                              // underfloor-heating actuator node
-    { material: "anhydrite",        thickness: 0.05 },
+    { material: "anhydrite",        thickness: 0.05 },  // walking surface (room side)
+    { marker: "heating" },                              // underfloor-heating actuator node, just under the screed
+    { material: "floor_insulation", thickness: 0.14 },  // blocks downward loss to the ground
+    { material: "concrete",         thickness: 0.20 },  // structural slab (ground side)
   ],
 },
 ```
@@ -112,9 +116,16 @@ ground_level_floor: {
   **solar surface**, and its absorbed flux is `irradiance × area × solar_absorptance`. Lower it for a
   reflective or **ventilated** assembly — e.g. the `roof` type uses `0.2`, because the air gap under
   the black tiles carries most of the absorbed heat away. Omit it (⇒ `1.0`) for a plain opaque face.
-- Beyond walls, the real `model.json5` instantiates this same Layered shape as `first_level_floor`
-  (the inter-floor slab), `venec` (the concrete + insulation ring-beam band below the ceiling), `roof`
-  (the insulated roof, carrying `solar_absorptance`), and `plaster_partition` (a single drywall layer).
+- Beyond walls, the real `model.json5` instantiates this same Layered shape as:
+  - **`first_level_floor`** — the inter-floor slab (UFH screed + marker + insulation + structural slab),
+    listed upper-room (`zones[0]`) → lower-room (`zones[1]`);
+  - **`first_level_ceiling`** — the light upper-room ceiling to the attic (drywall + rock wool);
+  - **`ground_level_ceiling`** — a **bare concrete slab** where a ground-floor ceiling meets the attic
+    *directly* (no heated room above it — the eave dead-space behind a knee wall, or behind the bathroom);
+  - **`venec`** — the věncovka + EPS + reinforced-concrete ring-beam band below each ceiling, listed
+    outside (`zones[0]`) → in (so `outside`/`garrage` is `zones[0]`);
+  - **`roof`** — the insulated roof, carrying `solar_absorptance`;
+  - **`plaster_partition`** — a single drywall layer.
 
 **Simple** — a massless element given by its U-value (windows, doors). **Simple boundaries get no
 solar gain** — only Layered surfaces become solar surfaces — so `g` (the solar heat-gain coefficient)
@@ -122,7 +133,8 @@ is currently parsed but **not used** by the thermal model; it is kept for forwar
 
 ```json5
 window:        { u: 0.74, g: 0.5 },   // U-value W/(m²·K); g (solar heat-gain coeff, 0–1) — currently unused
-entrance_door: { u: 1.2,  g: 0.0 },
+entrance_door: { u: 0.83, g: 0.52 },
+interior_door: { u: 2.8,  g: 0.0 },   // hollow-core; carved out of interior walls as a sub_boundary
 ```
 
 ### `boundaries`
@@ -153,6 +165,11 @@ boundaries: [
   house's true bearings — the example house is rotated ~50° off cardinal, so its faces are
   SE = 140°, SW = 230°, NW = 320°, NE = 50°.
 - Zero-area boundaries are skipped.
+- **Unheated buffer zones** (e.g. `attic`, `garrage`) are bounded like any other zone: their exterior
+  envelope uses `exterior_wall` / `venec` / `roof` to `outside`, and the heated rooms around them connect
+  via `first_level_ceiling` / `ground_level_ceiling` / interior walls. The attic, for instance, is closed
+  by its two roof slopes **plus** a NW gable and NE/SE eave walls (`exterior_wall` + `venec`) to `outside`
+  — give each sun-exposed face its `azimuth`/`angle` so it still collects solar onto the buffer.
 
 ---
 
@@ -186,8 +203,8 @@ heating: {
   cop: 1.0,                 // heat delivered per kWh electricity. 1.0 = resistive; >1 = a heat pump
   comfort_penalty: 50.0,    // price-units per K per step a zone is outside its band
   zones: {                  // a zone absent here is NOT heated
-    livingroom: { max_heat_kw: 4.0, t_min: 20.0, t_max: 23.0, internal_gain_w: 351 },
-    bedroom:    { max_heat_kw: 2.0, t_min: 19.0, t_max: 23.0 },
+    livingroom: { max_heat_kw: 3.0, t_min: 21.0, t_max: 24.0, internal_gain_w: 351 },
+    bedroom:    { max_heat_kw: 1.2, t_min: 20.0, t_max: 21.0 },
   },
 }
 ```

--- a/docs/ev.md
+++ b/docs/ev.md
@@ -150,7 +150,9 @@ them. Shadow only — nothing is actuated.
 
 ## Actuation (the EV controller — dry-run draft)
 
-The path to hardware mirrors the other [controllers](controllers.md) and ships **dry-run**:
+The path to hardware mirrors the other [controllers](controllers.md) and ships **dry-run**. (EV
+actuation can also run through the unified `mpc-controller-loxone` — see
+[loxone-controller-plan.md](loxone-controller-plan.md) — which supersedes this single-domain path.)
 
 ```
 plan /api/plan/latest ─▶ mpc-plan-publisher ─(MQTT mpc/control/ev)─▶ mpc-controller-ev ─(UDP)─▶ Loxone wallbox

--- a/docs/loxone-controller-plan.md
+++ b/docs/loxone-controller-plan.md
@@ -229,7 +229,7 @@ mirroring how `zone_mappings` already translates for sensors.
 `attic`, `garrage`, `outside` are **not heated** — no VI. **Dormancy:** a room registered in
 `config.heating.zones` + `zone_keys` still produces **no datagram** until its `model.json5` floor
 boundary carries a `"heating"` marker (the heated set is the intersection of marker ∩ config ∩ state).
-The 7 first-floor rooms are dormant until their model boundaries are finished.
+The 7 first-floor rooms are now **active** — their `model.json5` floor boundaries (with the `"heating"` marker) have landed.
 
 **EV (kW):** `EvChargePower` ✓ *(suggest `MPCEvPower` for prefix consistency — your call; it's one
 config row either way)*.

--- a/model.json5
+++ b/model.json5
@@ -634,44 +634,44 @@
         { "boundary_type": "venec",         "zones": ["outside", "attic"], "area": 1.60,  azimuth: 140, angle: 90 }, // 8 × 0.20 (model's standard venec band height)
         // ===== FIRST-FLOOR EXTERIOR ENVELOPE =====
         // Walls = the ground-floor `exterior_wall` (Heluz Family 2v1 44), split into the regular wall
-        // (gross area = length × 1.90 m, windows as sub-boundaries) + the `venec` ring-beam band
-        // (length × 0.20 m) right below the ceiling → 2.10 m of wall total (the owner's 1.90 + 0.20
-        // split, a touch under the 2.30 m clear height). Edge orientation (building rotated ~50° off cardinal):
+        // (gross area = length × 2.10 m, windows as sub-boundaries) + the `venec` ring-beam band
+        // (length × 0.20 m) right below the ceiling → 2.30 m of wall total (the owner's 2.10 + 0.20
+        // split = the full clear height). Edge orientation (building rotated ~50° off cardinal):
         // SE az140 / SW az230 / NW az320 / NE az50. Windows use the existing triple-glazed `window`
         // type (u 0.74 ≈ the Ug-0.50 units). Lengths from the DXF grid. FLAGGED (still approximate):
         // the guestroom NW-gable window position, and the bedroom SW garage/outside split.
         // --- az 230 (SW) — the long side, exterior + windows ---
         // closet SW side faces the (unheated) garage — not outside, so no sky orientation / solar gain.
         // garrage is a proxy for the garage attic above it (both unheated); revisit if we model that.
-        { "boundary_type": "exterior_wall", "zones": ["garrage", "first_floor_closet"], "area": 7.091 }, // 3.732 m → garage
+        { "boundary_type": "exterior_wall", "zones": ["garrage", "first_floor_closet"], "area": 7.837 }, // 3.732 m × 2.10 → garage
         { "boundary_type": "venec", "zones": ["garrage", "first_floor_closet"], "area": 0.746 },
         // bedroom SW wall splits: ~2.0 m → garage (top, by the closet) + ~1.98 m → outside (its window).
         // Both regular Heluz-44 exterior walls; the garage part has no sky orientation / solar. SPLIT ESTIMATED.
-        { "boundary_type": "exterior_wall", "zones": ["garrage", "bedroom"], "area": 3.800 }, // ~2.0 m → garage
+        { "boundary_type": "exterior_wall", "zones": ["garrage", "bedroom"], "area": 4.200 }, // ~2.0 m × 2.10 → garage
         { "boundary_type": "venec", "zones": ["garrage", "bedroom"], "area": 0.400 },
         {
-            "boundary_type": "exterior_wall", "zones": ["outside", "bedroom"], "area": 3.764, azimuth: 230, angle: 90, // ~1.98 m → outside
+            "boundary_type": "exterior_wall", "zones": ["outside", "bedroom"], "area": 4.160, azimuth: 230, angle: 90, // ~1.98 m × 2.10 → outside
             "sub_boundaries": [ { "boundary_type": "window", "area": 1.0 } ]      // 1000 × 1000
         },
         { "boundary_type": "venec", "zones": ["outside", "bedroom"], "area": 0.396, azimuth: 230, angle: 90 },
         {
-            "boundary_type": "exterior_wall", "zones": ["outside", "room_1"], "area": 8.130, azimuth: 230, angle: 90, // 4.279 m
+            "boundary_type": "exterior_wall", "zones": ["outside", "room_1"], "area": 8.986, azimuth: 230, angle: 90, // 4.279 m × 2.10
             "sub_boundaries": [ { "boundary_type": "window", "area": 1.455 } ]    // 1500 × 970
         },
         { "boundary_type": "venec", "zones": ["outside", "room_1"], "area": 0.856, azimuth: 230, angle: 90 },
         {
-            "boundary_type": "exterior_wall", "zones": ["outside", "room_2"], "area": 8.130, azimuth: 230, angle: 90, // 4.279 m
+            "boundary_type": "exterior_wall", "zones": ["outside", "room_2"], "area": 8.986, azimuth: 230, angle: 90, // 4.279 m × 2.10
             "sub_boundaries": [ { "boundary_type": "window", "area": 1.455 } ]    // 1500 × 970
         },
         { "boundary_type": "venec", "zones": ["outside", "room_2"], "area": 0.856, azimuth: 230, angle: 90 },
         {
-            "boundary_type": "exterior_wall", "zones": ["outside", "guestroom"], "area": 7.020, azimuth: 230, angle: 90, // 3.695 m (SW part)
+            "boundary_type": "exterior_wall", "zones": ["outside", "guestroom"], "area": 7.759, azimuth: 230, angle: 90, // 3.695 m × 2.10 (SW part)
             "sub_boundaries": [ { "boundary_type": "window", "area": 1.455 } ]    // 1500 × 970 (SW)
         },
         { "boundary_type": "venec", "zones": ["outside", "guestroom"], "area": 0.739, azimuth: 230, angle: 90 },
         // --- az 320 (NW) gable ---
         {
-            "boundary_type": "exterior_wall", "zones": ["outside", "guestroom"], "area": 12.903, azimuth: 320, angle: 90, // 6.791 m full width
+            "boundary_type": "exterior_wall", "zones": ["outside", "guestroom"], "area": 14.261, azimuth: 320, angle: 90, // 6.791 m × 2.10 full width
             "sub_boundaries": [ { "boundary_type": "window", "area": 1.455 } ]    // 1500 × 970 (NW gable)
         },
         { "boundary_type": "venec", "zones": ["outside", "guestroom"], "area": 1.358, azimuth: 320, angle: 90 },

--- a/model.json5
+++ b/model.json5
@@ -3,8 +3,8 @@
     //  - reserved zones `outside`/`ground` are no longer declared (auto-injected);
     //  - underfloor heating is a `{ marker: "heating" }` layer instead of a "heating" material;
     //  - surface orientation is carried via `azimuth`/`angle` (degrees) on exterior boundaries;
-    //  - the first-floor zones kept their volumes but their (unfinished) `adjacent_zones`
-    //    floor/ceiling topology was dropped — see the TODO in the zones block.
+    //  - the first-floor floor/ceiling/wall topology, dropped from PR #18's `adjacent_zones`,
+    //    has since been rebuilt as explicit tape-measured boundaries.
     "materials": {
         // NOTE: this `air` overrides the built-in default; its specific_heat_capacity (700)
         // is low for air (~1005 J/kg·K) — carried over verbatim from the branch, worth review.
@@ -67,6 +67,16 @@
             "thermal_conductivity": 0.035,
             "specific_heat_capacity": 1030.0,
             "density": 40.0
+        },
+        "spray_foam": { // closed-cell PUR sprayed under the rafters — the real roof thermal envelope
+            "thermal_conductivity": 0.030,
+            "specific_heat_capacity": 1400.0,
+            "density": 35.0
+        },
+        "vencovka": { // Heluz věncovka 8/2in1 — fired-clay shell with integrated polystyrene (insulating)
+            "thermal_conductivity": 0.090,
+            "specific_heat_capacity": 1000.0,
+            "density": 400.0
         }
     },
     "boundary_types": {
@@ -75,6 +85,18 @@
                 { "material": "ext_plaster", "thickness": 0.04 },
                 { "material": "brick_440", "thickness": 0.44 },
                 { "material": "int_plaster", "thickness": 0.02 }
+            ]
+        },
+        "venec": {
+            // Ring-beam band (~20 cm high) at the floor/ceiling junction of the Heluz Family 2v1 44
+            // wall. Inside→out: int. plaster + reinforced-concrete ring beam + laid EPS + Heluz věncovka
+            // 8/2in1. Same 0.44 core as the wall, but a modest thermal bridge (U≈0.19 vs the wall ~0.13).
+            "layers": [
+                { "material": "int_plaster", "thickness": 0.02 },
+                { "material": "concrete", "thickness": 0.20 },
+                { "material": "floor_insulation", "thickness": 0.16 },
+                { "material": "vencovka", "thickness": 0.08 },
+                { "material": "ext_plaster", "thickness": 0.04 }
             ]
         },
         "interior_wall_300": {
@@ -98,6 +120,13 @@
                 { "material": "int_plaster", "thickness": 0.02 }
             ]
         },
+        "plaster_partition": {
+            // A light plasterboard partition — just the board, no brick/insulation. E.g. the šatna's
+            // north wall, set back under the roof pitch so it clears the slope, facing the attic.
+            "layers": [
+                { "material": "drywall", "thickness": 0.0125 }
+            ]
+        },
         "ground_level_floor": {
             "layers": [
                 { "material": "concrete", "thickness": 0.20 },
@@ -106,22 +135,38 @@
                 { "material": "anhydrite", "thickness": 0.50 }
             ]
         },
-        "first_level_floor_bottom_layer": {
+        // Inter-floor slab: ONE boundary from the first-floor room (zone1, heated) down to the room
+        // below (zone2). Mirrors `ground_level_floor` — concrete slab + insulation + UFH marker +
+        // anhydrite screed — but with the thinner inter-floor insulation. PR #18 split this into a
+        // bottom+top pair meant to be stacked (`["...bottom_layer","...top_layer"]`); the current
+        // schema takes a single type, so the layers are combined here.
+        "first_level_floor": {
             "layers": [
-                { "material": "concrete", "thickness": 0.20 },
-                { "material": "floor_insulation", "thickness": 0.04 }
-            ]
-        },
-        "first_level_floor_top_layer": {
-            "layers": [
-                { marker: "heating" },
-                { "material": "anhydrite", "thickness": 0.40 }
+                { "material": "concrete", "thickness": 0.20 },        // structural slab (ceiling below)
+                { "material": "floor_insulation", "thickness": 0.04 },
+                { marker: "heating" },                                 // UFH → heats the first-floor room
+                { "material": "anhydrite", "thickness": 0.40 }         // screed (the first-floor room floor)
             ]
         },
         "first_level_ceiling": {
+            // Flat upper-floor ceiling: plasterboard + vapour barrier (thermally negligible, omitted)
+            // + 5 cm rock wool (mainly SOUND insulation). The real thermal barrier is the insulated
+            // 35° roof above the attic void, not this ceiling — so the attic sits inside the envelope.
             "layers": [
                 { "material": "drywall", "thickness": 0.02 },
                 { "material": "rock_wool", "thickness": 0.05 }
+            ]
+        },
+        "roof": {
+            // Insulated roof = ~30 cm sprayed PUR foam under the rafters (the thermal envelope). The
+            // vented air gap + black Figaro 11 tiles above are cladding OUTSIDE the envelope (between
+            // this and `outside`), so they're not layers here — their net effect is the reduced
+            // effective `solar_absorptance` below: black tile α≈0.9, but the mild air-gap ventilation
+            // carries off most of that heat (and the PV panels shade part), so only ~0.2 reaches the
+            // foam. Starting value — calibrate against measured attic temps.
+            "solar_absorptance": 0.2,
+            "layers": [
+                { "material": "spray_foam", "thickness": 0.30 }
             ]
         },
         "window": { "u": 0.74, "g": 0.5 },
@@ -149,20 +194,21 @@
         "ground_bathroom": { "volume": 15.87374 },
         "kitchen": { "volume": 62.0066 },
         "livingroom": { "volume": 102.6375 },
-        "storage": { "volume": 15.2337 },
-        "office": { "volume": 29.10398 },
-        // --- first floor: volumes known, but inter-floor/ceiling/wall topology is unfinished
-        //     in the source branch, so these zones are currently UNCONNECTED (no boundaries).
-        //     TODO: add first-floor walls, ceilings, and the floor boundaries to the rooms below
-        //     (the branch represented these via `adjacent_zones`, which the current schema drops).
-        "first_floor_hall": { "volume": 53.55708977 },
-        "first_floor_bathroom": { "volume": 21.86725157 },
-        "first_floor_closet": { "volume": 31.5675 },
-        "bedroom": { "volume": 34.84 },
-        "room_1": { "volume": 36.5769 },
-        "room_2": { "volume": 36.5769 },
-        "guestroom": { "volume": 75.67852925 }, // TODO: northern-wall height unmeasured
-        "attic": { "volume": 0.0 } // TODO: not yet modelled
+        "storage": { "volume": 14.496 },   // 5.6845 × 2.55 (2.984 × 1.905 footprint)
+        "office": { "volume": 29.003 },     // 11.3737 × 2.55 (3.809 × 2.986 footprint)
+        // --- first floor: 7 heated rooms under the unheated `attic` buffer. Air volume = the
+        //     tape-measured floor footprint × 2.30 m clear height. For the pitched rooms
+        //     (bathroom, hall, guestroom) the ceiling rises toward the ridge and drops to the knee
+        //     wall either side of that line; air heat capacity is a minor term next to the slab/wall
+        //     masses, so clear height is used uniformly.
+        "first_floor_hall": { "volume": 43.815 },      // 19.05 (solid floor) × 2.30
+        "first_floor_bathroom": { "volume": 21.852 },  // 9.501 × 2.30
+        "first_floor_closet": { "volume": 29.682 },    // 12.905 × 2.30
+        "bedroom": { "volume": 34.528 },               // 15.012 × 2.30
+        "room_1": { "volume": 37.124 },                // 16.141 × 2.30
+        "room_2": { "volume": 37.124 },                // 16.141 × 2.30
+        "guestroom": { "volume": 76.040 },             // 33.061 × 2.30
+        "attic": { "volume": 180.0 } // unheated roof-void buffer (est.; sets only the attic thermal lag)
     },
     "boundaries": [
         // ground floor entrance
@@ -188,9 +234,7 @@
             "area": 5.1,
             "sub_boundaries": [
                 { "boundary_type": "garrage_door", "area": 1.89 }
-            ],
-            azimuth: 230,
-            angle: 90
+            ]
         },
         {
             "boundary_type": "interior_wall_175",
@@ -287,9 +331,7 @@
             "area": 9.11625,
             "sub_boundaries": [
                 { "boundary_type": "garrage_door", "area": 1.89 }
-            ],
-            azimuth: 230,
-            angle: 90
+            ]
         },
         {
             "boundary_type": "interior_wall_175",
@@ -361,7 +403,7 @@
             "area": 40.25
         },
         {
-            "boundary_type": "exterior_wall", // north wall
+            "boundary_type": "exterior_wall", // NE wall (az 50)
             "zones": ["outside", "livingroom"],
             "area": 12.75,
             "sub_boundaries": [
@@ -437,7 +479,7 @@
         {
             "boundary_type": "ground_level_floor",
             "zones": ["storage", "ground"],
-            "area": 11.413327
+            "area": 5.6845
         },
         {
             "boundary_type": "exterior_wall",
@@ -455,7 +497,7 @@
         {
             "boundary_type": "ground_level_floor",
             "zones": ["office", "ground"],
-            "area": 5.974
+            "area": 11.3737
         },
         {
             "boundary_type": "exterior_wall",
@@ -473,7 +515,148 @@
             ],
             azimuth: 320,
             angle: 90
-        }
-        // TODO: first-floor walls/ceilings and the floor boundaries to the rooms below.
+        },
+        // --- first floor: inter-floor FLOORS. Each first-floor room (zone1, heated via its UFH
+        //     marker) sits on the room(s) below (zone2). Where a room spans several ground rooms its
+        //     floor is SPLIT across them (read off the DXF overlay); the split only distributes the
+        //     weak, insulated, low-ΔT downward coupling — the per-room total (= heating capacity) is
+        //     unchanged. Footprints are the TAPE-MEASURED room sizes (2026-06); each room's split is
+        //     scaled to its measured total. bathroom 9.50, closet 12.91, bedroom 15.01, hall 19.05
+        //     (solid, = footprint − stairwell void), room_1/2 16.14, guestroom 33.06 (L-shaped). The
+        //     top-floor splits (bathroom/closet/bedroom over the busy ground rooms) are least certain.
+        { "boundary_type": "first_level_floor", "zones": ["first_floor_bathroom", "ground_closet"],  "area": 5.3000 },
+        { "boundary_type": "first_level_floor", "zones": ["first_floor_bathroom", "toilet"],         "area": 2.4500 },
+        { "boundary_type": "first_level_floor", "zones": ["first_floor_bathroom", "entrance"],       "area": 1.7503 },
+        { "boundary_type": "first_level_floor", "zones": ["first_floor_closet", "technical_room"],   "area": 6.4800 },
+        { "boundary_type": "first_level_floor", "zones": ["first_floor_closet", "entrance"],         "area": 5.5200 },
+        { "boundary_type": "first_level_floor", "zones": ["first_floor_closet", "ground_closet"],    "area": 0.9061 },
+        { "boundary_type": "first_level_floor", "zones": ["bedroom", "ground_bathroom"],             "area": 6.2000 },
+        { "boundary_type": "first_level_floor", "zones": ["bedroom", "ground_hall"],                 "area": 4.5500 },
+        { "boundary_type": "first_level_floor", "zones": ["bedroom", "kitchen"],                     "area": 4.2620 },
+        { "boundary_type": "first_level_floor", "zones": ["first_floor_hall", "ground_hall"],        "area": 12.7800 },
+        { "boundary_type": "first_level_floor", "zones": ["first_floor_hall", "storage"],            "area": 5.6800 },
+        { "boundary_type": "first_level_floor", "zones": ["first_floor_hall", "ground_closet"],      "area": 0.5898 },
+        { "boundary_type": "first_level_floor", "zones": ["room_1", "livingroom"],                   "area": 10.5400 },
+        { "boundary_type": "first_level_floor", "zones": ["room_1", "kitchen"],                      "area": 5.6010 },
+        { "boundary_type": "first_level_floor", "zones": ["room_2", "livingroom"],                   "area": 9.9600 },
+        { "boundary_type": "first_level_floor", "zones": ["room_2", "kitchen"],                      "area": 6.1810 },
+        { "boundary_type": "first_level_floor", "zones": ["guestroom", "livingroom"],                "area": 15.3600 },
+        { "boundary_type": "first_level_floor", "zones": ["guestroom", "office"],                    "area": 11.3600 },
+        { "boundary_type": "first_level_floor", "zones": ["guestroom", "kitchen"],                   "area": 6.3400 },
+        // Stairwell: open vertical void — buoyant air exchange first_floor_hall <-> ground_hall.
+        {
+            "boundary_type": "open_space",
+            "zones": ["first_floor_hall", "ground_hall"],
+            "area": 8.332 // stairwell void, measured 2.102 × 3.964 m (flares to the outer wall)
+        },
+        // --- first-floor CEILINGS → the unheated `attic` buffer. Same assembly (plasterboard + 5 cm
+        //     rock wool) for all; only the AREA differs. Flat ceilings (bedroom, room_1, room_2, and
+        //     first_floor_closet*) use the footprint; the 35°-pitched ceilings (first_floor_bathroom,
+        //     first_floor_hall, guestroom) use footprint / cos(35°) ≈ ×1.221 (the real sloped area).
+        //     Above every ceiling — the open void, or the ~20 cm gap over a pitched one — is the attic.
+        //     (*first_floor_closet is modelled flat; its small pitched strip under the eave is
+        //     neglected. The hall + guestroom knee/hip walls are in the interior-walls section below.)
+        { "boundary_type": "first_level_ceiling", "zones": ["bedroom", "attic"], "area": 15.012 },
+        { "boundary_type": "first_level_ceiling", "zones": ["room_1", "attic"], "area": 16.141 },
+        { "boundary_type": "first_level_ceiling", "zones": ["room_2", "attic"], "area": 16.141 },
+        { "boundary_type": "first_level_ceiling", "zones": ["first_floor_closet", "attic"], "area": 12.905 },
+        { "boundary_type": "first_level_ceiling", "zones": ["first_floor_bathroom", "attic"], "area": 11.598 },  // 9.501 / cos35
+        { "boundary_type": "first_level_ceiling", "zones": ["first_floor_hall", "attic"], "area": 23.257 },      // 19.05 / cos35
+        { "boundary_type": "first_level_ceiling", "zones": ["guestroom", "attic"], "area": 40.354 },             // 33.061 / cos35
+        // Knee wall (110 cm tall, vertical) on the tapered eave side, hall + guestroom → attic — it caps
+        // the low end of the 35° ceilings so the rooms don't taper down to the floor. Modelled as a
+        // regular 175 mm interior wall; guestroom length 6.75 m (PR #18), hall ~6 m (ESTIMATE — confirm
+        // the hall length, and whether it's brick vs a lighter plasterboard stud partition).
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["guestroom", "attic"], "area": 7.156 },        // knee wall, NE leg 6.505 m × 1.10
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_hall", "attic"], "area": 5.514 }, // hip wall (AKU), (8.977−3.964) × 1.10
+        // --- ROOF: attic → outside. 35° pitch (angle 35), asymmetric hip+gable modelled as the two
+        //     main slopes — NE-facing (az 50) + SW-facing (az 230). Sloped area ≈ footprint / cos35;
+        //     the ~184 m² footprint → ~225 m² of roof, split ~half. ESTIMATE — refine from the krov plan.
+        {
+            "boundary_type": "roof",
+            "zones": ["attic", "outside"],
+            "area": 112.0,
+            azimuth: 50,
+            angle: 35
+        },
+        {
+            "boundary_type": "roof",
+            "zones": ["attic", "outside"],
+            "area": 112.0,
+            azimuth: 230,
+            angle: 35
+        },
+        // ===== FIRST-FLOOR EXTERIOR ENVELOPE =====
+        // Walls = the ground-floor `exterior_wall` (Heluz Family 2v1 44), split into the regular wall
+        // (gross area = length × 1.90 m, windows as sub-boundaries) + the `venec` ring-beam band
+        // (length × 0.20 m) right below the ceiling → 2.10 m of wall (the 2.30 m clear height less the
+        // floor build-up at the base). Edge orientation (building rotated ~50° off cardinal):
+        // SE az140 / SW az230 / NW az320 / NE az50. Windows use the existing triple-glazed `window`
+        // type (u 0.74 ≈ the Ug-0.50 units). Lengths from the DXF grid. FLAGGED (still approximate):
+        // the guestroom NW-gable window position, and the bedroom SW garage/outside split.
+        // --- az 230 (SW) — the long side, exterior + windows ---
+        // closet SW side faces the (unheated) garage — not outside, so no sky orientation / solar gain.
+        // garrage is a proxy for the garage attic above it (both unheated); revisit if we model that.
+        { "boundary_type": "exterior_wall", "zones": ["first_floor_closet", "garrage"], "area": 7.091 }, // 3.732 m → garage
+        { "boundary_type": "venec", "zones": ["first_floor_closet", "garrage"], "area": 0.746 },
+        // bedroom SW wall splits: ~2.0 m → garage (top, by the closet) + ~1.98 m → outside (its window).
+        // Both regular Heluz-44 exterior walls; the garage part has no sky orientation / solar. SPLIT ESTIMATED.
+        { "boundary_type": "exterior_wall", "zones": ["bedroom", "garrage"], "area": 3.800 }, // ~2.0 m → garage
+        { "boundary_type": "venec", "zones": ["bedroom", "garrage"], "area": 0.400 },
+        {
+            "boundary_type": "exterior_wall", "zones": ["bedroom", "outside"], "area": 3.764, azimuth: 230, angle: 90, // ~1.98 m → outside
+            "sub_boundaries": [ { "boundary_type": "window", "area": 1.0 } ]      // 1000 × 1000
+        },
+        { "boundary_type": "venec", "zones": ["bedroom", "outside"], "area": 0.396, azimuth: 230, angle: 90 },
+        {
+            "boundary_type": "exterior_wall", "zones": ["room_1", "outside"], "area": 8.130, azimuth: 230, angle: 90, // 4.279 m
+            "sub_boundaries": [ { "boundary_type": "window", "area": 1.455 } ]    // 1500 × 970
+        },
+        { "boundary_type": "venec", "zones": ["room_1", "outside"], "area": 0.856, azimuth: 230, angle: 90 },
+        {
+            "boundary_type": "exterior_wall", "zones": ["room_2", "outside"], "area": 8.130, azimuth: 230, angle: 90, // 4.279 m
+            "sub_boundaries": [ { "boundary_type": "window", "area": 1.455 } ]    // 1500 × 970
+        },
+        { "boundary_type": "venec", "zones": ["room_2", "outside"], "area": 0.856, azimuth: 230, angle: 90 },
+        {
+            "boundary_type": "exterior_wall", "zones": ["guestroom", "outside"], "area": 7.020, azimuth: 230, angle: 90, // 3.695 m (SW part)
+            "sub_boundaries": [ { "boundary_type": "window", "area": 1.455 } ]    // 1500 × 970 (SW)
+        },
+        { "boundary_type": "venec", "zones": ["guestroom", "outside"], "area": 0.739, azimuth: 230, angle: 90 },
+        // --- az 320 (NW) gable ---
+        {
+            "boundary_type": "exterior_wall", "zones": ["guestroom", "outside"], "area": 12.903, azimuth: 320, angle: 90, // 6.791 m full width
+            "sub_boundaries": [ { "boundary_type": "window", "area": 1.455 } ]    // 1500 × 970 (NW gable)
+        },
+        { "boundary_type": "venec", "zones": ["guestroom", "outside"], "area": 1.358, azimuth: 320, angle: 90 },
+        // --- az 50 (NE) ---
+        // The guestroom NE leg and the hall both face the ATTIC here (knee/hip wall → attic, in the
+        // attic-walls section) — NOT a vertical exterior wall, except the hall's low parapet at the
+        // stairwell. first_floor_hall reaches the exterior ONLY there: a ~50 cm parapet, with a
+        // plaster + vapour + 5 cm rock-wool panel above it → attic. Opening 3.964 m long.
+        { "boundary_type": "exterior_wall", "zones": ["first_floor_hall", "outside"], "area": 1.982, azimuth: 50, angle: 90 }, // 3.964 m × 0.50 parapet
+        { "boundary_type": "first_level_ceiling", "zones": ["first_floor_hall", "attic"], "area": 3.171 },                     // panel above the parapet → attic (3.964 × 0.80)
+        // (No vertical exterior wall on the N/az140 end — it's the hipped roof eave: both
+        //  first_floor_bathroom and first_floor_closet face the attic there, not outside; their
+        //  attic-facing walls are in the interior-walls section below.),
+        // --- first-floor INTERIOR walls (Heluz AKU Z 17.5 = interior_wall_175_accoustic + plaster),
+        //     full 2.30 m clear height. Shared-wall lengths from the DXF grid (room adjacencies).
+        //     Interior doors not modelled yet. (Heights: interior = 2.30 m clear vs exterior 2.10 m —
+        //     flag if you want them matched.)
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_bathroom", "first_floor_closet"], "area": 5.152 }, // E wall, upper 2.24 m
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_bathroom", "bedroom"],            "area": 2.300 }, // E wall, lower ~1.0 m
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_bathroom", "first_floor_hall"],   "area": 6.394 }, // NW side (az320), 2.78 m
+        // Bathroom is internal: its SE (az140, 2.766 m) + NE (az50, 3.435 m) sides face the attic. Height
+        // assumed full clear 2.30 m — reduce if the pitched ceiling lowers those eave-side walls.
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_bathroom", "attic"],             "area": 14.262 }, // (2.766+3.435) × 2.30
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_closet", "bedroom"],              "area": 8.740 }, // 3.80 m
+        // Šatna nahoře (closet) N wall — set back under the roof pitch, just plasterboard, faces attic.
+        { "boundary_type": "plaster_partition", "zones": ["first_floor_closet", "attic"],                         "area": 7.953 }, // 3.458 m × 2.30
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_hall", "bedroom"],                "area": 6.739 }, // 2.93 m
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_hall", "room_1"],                 "area": 10.465 },// 4.55 m
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_hall", "room_2"],                 "area": 2.622 }, // 1.14 m
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["bedroom", "room_1"],                          "area": 8.740 }, // 3.80 m
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["room_1", "room_2"],                           "area": 8.740 }, // 3.80 m
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["room_2", "guestroom"],                        "area": 8.740 }  // 3.80 m
     ]
 }

--- a/model.json5
+++ b/model.json5
@@ -6,11 +6,11 @@
     //  - the first-floor floor/ceiling/wall topology, dropped from PR #18's `adjacent_zones`,
     //    has since been rebuilt as explicit tape-measured boundaries.
     "materials": {
-        // NOTE: this `air` overrides the built-in default; its specific_heat_capacity (700)
-        // is low for air (~1005 J/kg·K) — carried over verbatim from the branch, worth review.
+        // NOTE: this `air` overrides the built-in default; specific_heat_capacity 1012 J/(kg·K) is
+        // standard air (matching the uom built-in) — the previous 700 was a carry-over error.
         "air": {
             "thermal_conductivity": 0.026,
-            "specific_heat_capacity": 700.0,
+            "specific_heat_capacity": 1012.0,
             "density": 1.199
         },
         "brick_440": { // Heluz Family 2v1 44
@@ -54,7 +54,7 @@
             "density": 2050.0, // 2000-2100
         },
         "concrete": { // Concrete C 20/25
-            "thermal_conductivity": 1.5, // 1.23-1774
+            "thermal_conductivity": 1.5, // 1.23-1.74
             "specific_heat_capacity": 1020.0,
             "density": 2250.0, // 2200-2300
         },
@@ -89,14 +89,16 @@
         },
         "venec": {
             // Ring-beam band (~20 cm high) at the floor/ceiling junction of the Heluz Family 2v1 44
-            // wall. Inside→out: int. plaster + reinforced-concrete ring beam + laid EPS + Heluz věncovka
-            // 8/2in1. Same 0.44 core as the wall, but a modest thermal bridge (U≈0.19 vs the wall ~0.13).
+            // wall. Listed outside→in (same direction as `exterior_wall`, so `outside`/`garrage` is
+            // zones[0]): ext. plaster + Heluz věncovka 8/2in1 + laid EPS + reinforced-concrete ring
+            // beam + int. plaster. The 16 cm EPS + věncovka shell keep it well-insulated (U≈0.16,
+            // close to the wall's ~0.13 — not a thermal bridge).
             "layers": [
-                { "material": "int_plaster", "thickness": 0.02 },
-                { "material": "concrete", "thickness": 0.20 },
-                { "material": "floor_insulation", "thickness": 0.16 },
+                { "material": "ext_plaster", "thickness": 0.04 },
                 { "material": "vencovka", "thickness": 0.08 },
-                { "material": "ext_plaster", "thickness": 0.04 }
+                { "material": "floor_insulation", "thickness": 0.16 },
+                { "material": "concrete", "thickness": 0.20 },
+                { "material": "int_plaster", "thickness": 0.02 }
             ]
         },
         "interior_wall_300": {
@@ -128,11 +130,13 @@
             ]
         },
         "ground_level_floor": {
+            // Listed room-side (zones[0]) → ground-side (zones[1]): screed on top, UFH just under it,
+            // insulation below (directs heat up), structural slab at the bottom.
             "layers": [
-                { "material": "concrete", "thickness": 0.20 },
-                { "material": "floor_insulation", "thickness": 0.14 },
-                { marker: "heating" }, // underfloor heating injection node
-                { "material": "anhydrite", "thickness": 0.50 }
+                { "material": "anhydrite", "thickness": 0.05 },        // room-side screed (walking surface)
+                { marker: "heating" },                                 // UFH, just under the screed
+                { "material": "floor_insulation", "thickness": 0.14 }, // blocks downward loss to the ground
+                { "material": "concrete", "thickness": 0.20 }          // structural slab (ground side)
             ]
         },
         // Inter-floor slab: ONE boundary from the first-floor room (zone1, heated) down to the room
@@ -141,11 +145,12 @@
         // bottom+top pair meant to be stacked (`["...bottom_layer","...top_layer"]`); the current
         // schema takes a single type, so the layers are combined here.
         "first_level_floor": {
+            // Listed room-side (zones[0] = the first-floor room) → down to the room below (zones[1]).
             "layers": [
-                { "material": "concrete", "thickness": 0.20 },        // structural slab (ceiling below)
-                { "material": "floor_insulation", "thickness": 0.04 },
-                { marker: "heating" },                                 // UFH → heats the first-floor room
-                { "material": "anhydrite", "thickness": 0.40 }         // screed (the first-floor room floor)
+                { "material": "anhydrite", "thickness": 0.04 },        // first-floor room screed (walking surface)
+                { marker: "heating" },                                 // UFH, just under the screed → heats the room above
+                { "material": "floor_insulation", "thickness": 0.04 }, // blocks downward loss
+                { "material": "concrete", "thickness": 0.20 }          // structural slab = ceiling of the room below
             ]
         },
         "first_level_ceiling": {
@@ -155,6 +160,16 @@
             "layers": [
                 { "material": "drywall", "thickness": 0.02 },
                 { "material": "rock_wool", "thickness": 0.05 }
+            ]
+        },
+        "ground_level_ceiling": {
+            // Bare structural concrete slab exposed directly to the attic from below — the part of a
+            // ground-floor ceiling that extends past the heated first-floor room above: the eave
+            // dead-space behind the upstairs knee wall, and the strip behind the bathroom. No room sits
+            // above it ⇒ no UFH / screed; the attic is inside the envelope (insulated roof), so the bare
+            // slab is the only layer.
+            "layers": [
+                { "material": "concrete", "thickness": 0.20 }
             ]
         },
         "roof": {
@@ -172,8 +187,8 @@
         "window": { "u": 0.74, "g": 0.5 },
         "hs_portal": { "u": 0.96, "g": 0.52 },
         "entrance_door": { "u": 0.83, "g": 0.52 },
-        "garrage_door": { "u": 0.83, "g": 0.52 },
-        "interior_door": { "u": 0.60, "g": 0.0 },
+        "garrage_door": { "u": 0.83, "g": 0.0 }, // opaque insulated house↔garage door (interior, no solar)
+        "interior_door": { "u": 2.8, "g": 0.0 }, // hollow-core: recycled-paper honeycomb + wooden frame, 210 cm high
         // Open passage (no wall): heat crosses as buoyant air exchange, not conduction. Modelled as a
         // single resistor whose `u` is the effective convective coupling per m² of opening. The
         // large-opening buoyancy model gives ~80-90 W/m²K for a room-height gap (more for a taller
@@ -230,7 +245,7 @@
         },
         {
             "boundary_type": "exterior_wall",
-            "zones": ["entrance", "garrage"],
+            "zones": ["garrage", "entrance"],
             "area": 5.1,
             "sub_boundaries": [
                 { "boundary_type": "garrage_door", "area": 1.89 }
@@ -262,7 +277,7 @@
         },
         {
             "boundary_type": "exterior_wall",
-            "zones": ["ground_closet", "outside"],
+            "zones": ["outside", "ground_closet"],
             "area": 6.5025,
             "sub_boundaries": [
                 { "boundary_type": "window", "area": 1.7125 }
@@ -272,7 +287,7 @@
         },
         {
             "boundary_type": "exterior_wall",
-            "zones": ["ground_closet", "outside"],
+            "zones": ["outside", "ground_closet"],
             "area": 9.333,
             azimuth: 50,
             angle: 90
@@ -306,7 +321,7 @@
         },
         {
             "boundary_type": "exterior_wall",
-            "zones": ["toilet", "outside"],
+            "zones": ["outside", "toilet"],
             "area": 3.009,
             azimuth: 50,
             angle: 90
@@ -327,7 +342,7 @@
         },
         {
             "boundary_type": "exterior_wall",
-            "zones": ["technical_room", "garrage"],
+            "zones": ["garrage", "technical_room"],
             "area": 9.11625,
             "sub_boundaries": [
                 { "boundary_type": "garrage_door", "area": 1.89 }
@@ -346,7 +361,7 @@
         },
         {
             "boundary_type": "exterior_wall",
-            "zones": ["ground_bathroom", "outside"],
+            "zones": ["outside", "ground_bathroom"],
             "area": 9.11625,
             "sub_boundaries": [
                 { "boundary_type": "window", "area": 1.22 }
@@ -388,7 +403,7 @@
         },
         {
             "boundary_type": "exterior_wall",
-            "zones": ["ground_hall", "outside"],
+            "zones": ["outside", "ground_hall"],
             "area": 10.2,
             "sub_boundaries": [
                 { "boundary_type": "window", "area": 1.5 }
@@ -529,13 +544,13 @@
         { "boundary_type": "first_level_floor", "zones": ["first_floor_bathroom", "entrance"],       "area": 1.7503 },
         { "boundary_type": "first_level_floor", "zones": ["first_floor_closet", "technical_room"],   "area": 6.4800 },
         { "boundary_type": "first_level_floor", "zones": ["first_floor_closet", "entrance"],         "area": 5.5200 },
-        { "boundary_type": "first_level_floor", "zones": ["first_floor_closet", "ground_closet"],    "area": 0.9061 },
+        { "boundary_type": "first_level_floor", "zones": ["first_floor_closet", "ground_closet"],    "area": 0.9052 },
         { "boundary_type": "first_level_floor", "zones": ["bedroom", "ground_bathroom"],             "area": 6.2000 },
-        { "boundary_type": "first_level_floor", "zones": ["bedroom", "ground_hall"],                 "area": 4.5500 },
-        { "boundary_type": "first_level_floor", "zones": ["bedroom", "kitchen"],                     "area": 4.2620 },
-        { "boundary_type": "first_level_floor", "zones": ["first_floor_hall", "ground_hall"],        "area": 12.7800 },
+        { "boundary_type": "first_level_floor", "zones": ["bedroom", "livingroom"],                  "area": 4.3900 }, // bedroom spans the bathroom/kitchen/living block; ground_hall's ceiling is already fully tiled by first_floor_hall + the stairwell void
+        { "boundary_type": "first_level_floor", "zones": ["bedroom", "kitchen"],                     "area": 4.4220 },
+        { "boundary_type": "first_level_floor", "zones": ["first_floor_hall", "ground_hall"],        "area": 11.2970 }, // solid slab; + the 8.332 stairwell void below = 19.629 = ground_hall footprint
         { "boundary_type": "first_level_floor", "zones": ["first_floor_hall", "storage"],            "area": 5.6800 },
-        { "boundary_type": "first_level_floor", "zones": ["first_floor_hall", "ground_closet"],      "area": 0.5898 },
+        { "boundary_type": "first_level_floor", "zones": ["first_floor_hall", "ground_closet"],      "area": 2.0728 }, // ground_closet's share of the hall floor (raised from 0.59 so ground_hall's solid floor + stairwell void = its footprint)
         { "boundary_type": "first_level_floor", "zones": ["room_1", "livingroom"],                   "area": 10.5400 },
         { "boundary_type": "first_level_floor", "zones": ["room_1", "kitchen"],                      "area": 5.6010 },
         { "boundary_type": "first_level_floor", "zones": ["room_2", "livingroom"],                   "area": 9.9600 },
@@ -560,103 +575,137 @@
         { "boundary_type": "first_level_ceiling", "zones": ["room_1", "attic"], "area": 16.141 },
         { "boundary_type": "first_level_ceiling", "zones": ["room_2", "attic"], "area": 16.141 },
         { "boundary_type": "first_level_ceiling", "zones": ["first_floor_closet", "attic"], "area": 12.905 },
-        { "boundary_type": "first_level_ceiling", "zones": ["first_floor_bathroom", "attic"], "area": 11.598 },  // 9.501 / cos35
-        { "boundary_type": "first_level_ceiling", "zones": ["first_floor_hall", "attic"], "area": 23.257 },      // 19.05 / cos35
-        { "boundary_type": "first_level_ceiling", "zones": ["guestroom", "attic"], "area": 40.354 },             // 33.061 / cos35
+        // first_floor_bathroom ceiling, owner-measured (replaces the 9.501/cos35 = 11.598 estimate):
+        { "boundary_type": "first_level_ceiling", "zones": ["first_floor_bathroom", "attic"], "area": 6.832 },   // sloped, 1.990 × 3.433
+        { "boundary_type": "first_level_ceiling", "zones": ["first_floor_bathroom", "attic"], "area": 3.824 },   // flat, 1.115 × 3.430
+        // first_floor_hall ceiling, owner-measured (replaces the 19.05/cos35 = 23.257 estimate; the
+        // separate parapet closure panel below stays):
+        { "boundary_type": "first_level_ceiling", "zones": ["first_floor_hall", "attic"], "area": 10.484 },      // taper above the staircase, 2.646 × 3.962
+        { "boundary_type": "first_level_ceiling", "zones": ["first_floor_hall", "attic"], "area": 10.450 },      // taper above the hall, 2.082 × 5.019
+        { "boundary_type": "first_level_ceiling", "zones": ["first_floor_hall", "attic"], "area": 10.171 },      // flat piece along the house length, 1.133 × 8.977
+        // guestroom ceiling, owner-measured (replaces the all-sloped 33.061/cos35 = 40.354 estimate):
+        { "boundary_type": "first_level_ceiling", "zones": ["guestroom", "attic"], "area": 14.610 },            // flat ceiling, 3.955 × 3.693
+        { "boundary_type": "first_level_ceiling", "zones": ["guestroom", "attic"], "area": 13.340 },            // angled (sloped) roof, 2.05 × 6.506
+        { "boundary_type": "first_level_ceiling", "zones": ["guestroom", "attic"], "area": 7.566 },             // long strip along the house, 1.163 × 6.506
+        // Ground-floor ceiling where NO heated first-floor room sits above (eave dead-space behind the
+        // knee wall + the strip behind the bathroom): a bare concrete slab straight to the attic. Areas
+        // = each room's footprint − the first-floor floor above it, so every ground ceiling now tiles fully.
+        { "boundary_type": "ground_level_ceiling", "zones": ["technical_room", "attic"], "area": 4.2450 }, // behind the ground_bathroom
+        { "boundary_type": "ground_level_ceiling", "zones": ["kitchen", "attic"],        "area": 1.7723 },
+        { "boundary_type": "ground_level_ceiling", "zones": ["entrance", "attic"],       "area": 1.8797 },
+        { "boundary_type": "ground_level_ceiling", "zones": ["ground_closet", "attic"],  "area": 1.0541 },
+        { "boundary_type": "ground_level_ceiling", "zones": ["toilet", "attic"],         "area": 0.5425 },
         // Knee wall (110 cm tall, vertical) on the tapered eave side, hall + guestroom → attic — it caps
         // the low end of the 35° ceilings so the rooms don't taper down to the floor. Modelled as a
-        // regular 175 mm interior wall; guestroom length 6.75 m (PR #18), hall ~6 m (ESTIMATE — confirm
-        // the hall length, and whether it's brick vs a lighter plasterboard stud partition).
+        // regular 175 mm interior wall (lengths on the boundary lines below; confirm whether it's brick
+        // vs a lighter plasterboard stud partition).
         { "boundary_type": "interior_wall_175_accoustic", "zones": ["guestroom", "attic"], "area": 7.156 },        // knee wall, NE leg 6.505 m × 1.10
         { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_hall", "attic"], "area": 5.514 }, // hip wall (AKU), (8.977−3.964) × 1.10
         // --- ROOF: attic → outside. 35° pitch (angle 35), asymmetric hip+gable modelled as the two
-        //     main slopes — NE-facing (az 50) + SW-facing (az 230). Sloped area ≈ footprint / cos35;
-        //     the ~184 m² footprint → ~225 m² of roof, split ~half. ESTIMATE — refine from the krov plan.
+        //     main slopes — NE-facing (az 50) + SW-facing (az 230). Sloped area = footprint / cos35;
+        //     the heated first-floor footprint 121.8 m² → ~149 m² of roof, split ~half here (the ridge
+        //     is off-centre, so refine the NE/SW split from the krov plan).
         {
             "boundary_type": "roof",
             "zones": ["attic", "outside"],
-            "area": 112.0,
+            "area": 74.35,
             azimuth: 50,
             angle: 35
         },
         {
             "boundary_type": "roof",
             "zones": ["attic", "outside"],
-            "area": 112.0,
+            "area": 74.35,
             azimuth: 230,
             angle: 35
         },
+        // ===== ATTIC EXTERIOR PERIMETER (attic → outside) =====
+        // Beyond the two roof slopes the attic is closed by: a vertical gable on the NW end only, and low
+        // brick eave walls (2 Heluz courses ≈ 0.50 m) along the NE and SE. The věnec ring beam at this level
+        // is already carried by the first-floor rooms (e.g. the guestroom az320/az230 venec), so it is added
+        // below ONLY for the SE end, which has no first-floor room under it.
+        // NW gable (štít, az320) — the ONLY vertical gable: triangle, 5.1 m base, 35° both slopes →
+        // peak (5.1/2)·tan35 = 1.786 m, area ½·5.1·1.786 = 4.55 m²:
+        { "boundary_type": "exterior_wall", "zones": ["outside", "attic"], "area": 4.553, azimuth: 320, angle: 90 },
+        // NE eave wall (az50), 23 m long, ~0.50 m high (věnec already in the rooms):
+        { "boundary_type": "exterior_wall", "zones": ["outside", "attic"], "area": 11.50, azimuth: 50,  angle: 90 }, // 23 × 0.50
+        // SE eave wall (az140), 8 m long, same height, + its own věnec (no first-floor room here):
+        { "boundary_type": "exterior_wall", "zones": ["outside", "attic"], "area": 4.00,  azimuth: 140, angle: 90 }, // 8 × 0.50
+        { "boundary_type": "venec",         "zones": ["outside", "attic"], "area": 1.60,  azimuth: 140, angle: 90 }, // 8 × 0.20 (model's standard venec band height)
         // ===== FIRST-FLOOR EXTERIOR ENVELOPE =====
         // Walls = the ground-floor `exterior_wall` (Heluz Family 2v1 44), split into the regular wall
         // (gross area = length × 1.90 m, windows as sub-boundaries) + the `venec` ring-beam band
-        // (length × 0.20 m) right below the ceiling → 2.10 m of wall (the 2.30 m clear height less the
-        // floor build-up at the base). Edge orientation (building rotated ~50° off cardinal):
+        // (length × 0.20 m) right below the ceiling → 2.10 m of wall total (the owner's 1.90 + 0.20
+        // split, a touch under the 2.30 m clear height). Edge orientation (building rotated ~50° off cardinal):
         // SE az140 / SW az230 / NW az320 / NE az50. Windows use the existing triple-glazed `window`
         // type (u 0.74 ≈ the Ug-0.50 units). Lengths from the DXF grid. FLAGGED (still approximate):
         // the guestroom NW-gable window position, and the bedroom SW garage/outside split.
         // --- az 230 (SW) — the long side, exterior + windows ---
         // closet SW side faces the (unheated) garage — not outside, so no sky orientation / solar gain.
         // garrage is a proxy for the garage attic above it (both unheated); revisit if we model that.
-        { "boundary_type": "exterior_wall", "zones": ["first_floor_closet", "garrage"], "area": 7.091 }, // 3.732 m → garage
-        { "boundary_type": "venec", "zones": ["first_floor_closet", "garrage"], "area": 0.746 },
+        { "boundary_type": "exterior_wall", "zones": ["garrage", "first_floor_closet"], "area": 7.091 }, // 3.732 m → garage
+        { "boundary_type": "venec", "zones": ["garrage", "first_floor_closet"], "area": 0.746 },
         // bedroom SW wall splits: ~2.0 m → garage (top, by the closet) + ~1.98 m → outside (its window).
         // Both regular Heluz-44 exterior walls; the garage part has no sky orientation / solar. SPLIT ESTIMATED.
-        { "boundary_type": "exterior_wall", "zones": ["bedroom", "garrage"], "area": 3.800 }, // ~2.0 m → garage
-        { "boundary_type": "venec", "zones": ["bedroom", "garrage"], "area": 0.400 },
+        { "boundary_type": "exterior_wall", "zones": ["garrage", "bedroom"], "area": 3.800 }, // ~2.0 m → garage
+        { "boundary_type": "venec", "zones": ["garrage", "bedroom"], "area": 0.400 },
         {
-            "boundary_type": "exterior_wall", "zones": ["bedroom", "outside"], "area": 3.764, azimuth: 230, angle: 90, // ~1.98 m → outside
+            "boundary_type": "exterior_wall", "zones": ["outside", "bedroom"], "area": 3.764, azimuth: 230, angle: 90, // ~1.98 m → outside
             "sub_boundaries": [ { "boundary_type": "window", "area": 1.0 } ]      // 1000 × 1000
         },
-        { "boundary_type": "venec", "zones": ["bedroom", "outside"], "area": 0.396, azimuth: 230, angle: 90 },
+        { "boundary_type": "venec", "zones": ["outside", "bedroom"], "area": 0.396, azimuth: 230, angle: 90 },
         {
-            "boundary_type": "exterior_wall", "zones": ["room_1", "outside"], "area": 8.130, azimuth: 230, angle: 90, // 4.279 m
+            "boundary_type": "exterior_wall", "zones": ["outside", "room_1"], "area": 8.130, azimuth: 230, angle: 90, // 4.279 m
             "sub_boundaries": [ { "boundary_type": "window", "area": 1.455 } ]    // 1500 × 970
         },
-        { "boundary_type": "venec", "zones": ["room_1", "outside"], "area": 0.856, azimuth: 230, angle: 90 },
+        { "boundary_type": "venec", "zones": ["outside", "room_1"], "area": 0.856, azimuth: 230, angle: 90 },
         {
-            "boundary_type": "exterior_wall", "zones": ["room_2", "outside"], "area": 8.130, azimuth: 230, angle: 90, // 4.279 m
+            "boundary_type": "exterior_wall", "zones": ["outside", "room_2"], "area": 8.130, azimuth: 230, angle: 90, // 4.279 m
             "sub_boundaries": [ { "boundary_type": "window", "area": 1.455 } ]    // 1500 × 970
         },
-        { "boundary_type": "venec", "zones": ["room_2", "outside"], "area": 0.856, azimuth: 230, angle: 90 },
+        { "boundary_type": "venec", "zones": ["outside", "room_2"], "area": 0.856, azimuth: 230, angle: 90 },
         {
-            "boundary_type": "exterior_wall", "zones": ["guestroom", "outside"], "area": 7.020, azimuth: 230, angle: 90, // 3.695 m (SW part)
+            "boundary_type": "exterior_wall", "zones": ["outside", "guestroom"], "area": 7.020, azimuth: 230, angle: 90, // 3.695 m (SW part)
             "sub_boundaries": [ { "boundary_type": "window", "area": 1.455 } ]    // 1500 × 970 (SW)
         },
-        { "boundary_type": "venec", "zones": ["guestroom", "outside"], "area": 0.739, azimuth: 230, angle: 90 },
+        { "boundary_type": "venec", "zones": ["outside", "guestroom"], "area": 0.739, azimuth: 230, angle: 90 },
         // --- az 320 (NW) gable ---
         {
-            "boundary_type": "exterior_wall", "zones": ["guestroom", "outside"], "area": 12.903, azimuth: 320, angle: 90, // 6.791 m full width
+            "boundary_type": "exterior_wall", "zones": ["outside", "guestroom"], "area": 12.903, azimuth: 320, angle: 90, // 6.791 m full width
             "sub_boundaries": [ { "boundary_type": "window", "area": 1.455 } ]    // 1500 × 970 (NW gable)
         },
-        { "boundary_type": "venec", "zones": ["guestroom", "outside"], "area": 1.358, azimuth: 320, angle: 90 },
+        { "boundary_type": "venec", "zones": ["outside", "guestroom"], "area": 1.358, azimuth: 320, angle: 90 },
         // --- az 50 (NE) ---
         // The guestroom NE leg and the hall both face the ATTIC here (knee/hip wall → attic, in the
         // attic-walls section) — NOT a vertical exterior wall, except the hall's low parapet at the
         // stairwell. first_floor_hall reaches the exterior ONLY there: a ~50 cm parapet, with a
         // plaster + vapour + 5 cm rock-wool panel above it → attic. Opening 3.964 m long.
-        { "boundary_type": "exterior_wall", "zones": ["first_floor_hall", "outside"], "area": 1.982, azimuth: 50, angle: 90 }, // 3.964 m × 0.50 parapet
-        { "boundary_type": "first_level_ceiling", "zones": ["first_floor_hall", "attic"], "area": 3.171 },                     // panel above the parapet → attic (3.964 × 0.80)
-        // (No vertical exterior wall on the N/az140 end — it's the hipped roof eave: both
+        { "boundary_type": "exterior_wall", "zones": ["outside", "first_floor_hall"], "area": 1.982, azimuth: 50, angle: 90 }, // 3.964 m × 0.50 parapet
+        { "boundary_type": "venec", "zones": ["outside", "first_floor_hall"], "area": 0.793, azimuth: 50, angle: 90 },         // 3.964 m × 0.20 ring beam over the parapet
+        { "boundary_type": "first_level_ceiling", "zones": ["first_floor_hall", "attic"], "area": 3.171 },                     // closure panel above the parapet → attic; the same plasterboard + rock-wool assembly as a ceiling, not a brick wall (3.964 × 0.80)
+        // (No vertical exterior wall on the SE/az140 end — it's the hipped roof eave: both
         //  first_floor_bathroom and first_floor_closet face the attic there, not outside; their
         //  attic-facing walls are in the interior-walls section below.),
         // --- first-floor INTERIOR walls (Heluz AKU Z 17.5 = interior_wall_175_accoustic + plaster),
         //     full 2.30 m clear height. Shared-wall lengths from the DXF grid (room adjacencies).
-        //     Interior doors not modelled yet. (Heights: interior = 2.30 m clear vs exterior 2.10 m —
-        //     flag if you want them matched.)
-        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_bathroom", "first_floor_closet"], "area": 5.152 }, // E wall, upper 2.24 m
-        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_bathroom", "bedroom"],            "area": 2.300 }, // E wall, lower ~1.0 m
-        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_bathroom", "first_floor_hall"],   "area": 6.394 }, // NW side (az320), 2.78 m
-        // Bathroom is internal: its SE (az140, 2.766 m) + NE (az50, 3.435 m) sides face the attic. Height
-        // assumed full clear 2.30 m — reduce if the pitched ceiling lowers those eave-side walls.
-        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_bathroom", "attic"],             "area": 14.262 }, // (2.766+3.435) × 2.30
+        //     Interior doors (210 cm high, hollow-core recycled-paper + wood) carved into each room↔hall wall.
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_bathroom", "first_floor_closet"], "area": 5.152 }, // SW wall, closet part 2.24 m × 2.30
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_bathroom", "bedroom"],            "area": 2.749 }, // SW wall, bedroom part 1.195 m × 2.30 (sum = 3.435 m edge)
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_bathroom", "first_floor_hall"],   "area": 6.394, "sub_boundaries": [ { "boundary_type": "interior_door", "area": 1.47 } ] }, // NW side (shared with hall), 2.78 m + door
+        // Bathroom is internal: its SE (az140, 2.766 m) + NE (az50, 3.435 m) sides face the attic. Pitched
+        // room, so these reach only the ~1.10 m knee; the pitched ceiling above carries the rest.
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_bathroom", "attic"],             "area": 6.821 }, // (2.766+3.435) × 1.10 (knee)
         { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_closet", "bedroom"],              "area": 8.740 }, // 3.80 m
         // Šatna nahoře (closet) N wall — set back under the roof pitch, just plasterboard, faces attic.
         { "boundary_type": "plaster_partition", "zones": ["first_floor_closet", "attic"],                         "area": 7.953 }, // 3.458 m × 2.30
-        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_hall", "bedroom"],                "area": 6.739 }, // 2.93 m
-        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_hall", "room_1"],                 "area": 10.465 },// 4.55 m
-        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_hall", "room_2"],                 "area": 2.622 }, // 1.14 m
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_closet", "first_floor_hall"],     "area": 2.806, "sub_boundaries": [ { "boundary_type": "interior_door", "area": 1.47 } ] }, // S-side gap, 1.22 m × 2.30 + door
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_hall", "bedroom"],                "area": 6.739, "sub_boundaries": [ { "boundary_type": "interior_door", "area": 1.68 } ] }, // 2.93 m + door
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_hall", "room_1"],                 "area": 10.465, "sub_boundaries": [ { "boundary_type": "interior_door", "area": 1.68 } ] },// 4.55 m + door
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_hall", "room_2"],                 "area": 2.622, "sub_boundaries": [ { "boundary_type": "interior_door", "area": 1.68 } ] }, // 1.14 m + door
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["first_floor_hall", "guestroom"],              "area": 6.518, "sub_boundaries": [ { "boundary_type": "interior_door", "area": 1.68 } ] }, // hall end → guestroom, 2.834 m × 2.30 + door
         { "boundary_type": "interior_wall_175_accoustic", "zones": ["bedroom", "room_1"],                          "area": 8.740 }, // 3.80 m
         { "boundary_type": "interior_wall_175_accoustic", "zones": ["room_1", "room_2"],                           "area": 8.740 }, // 3.80 m
-        { "boundary_type": "interior_wall_175_accoustic", "zones": ["room_2", "guestroom"],                        "area": 8.740 }  // 3.80 m
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["room_2", "guestroom"],                        "area": 8.740 }, // 3.80 m (E side, spine→exterior)
+        { "boundary_type": "interior_wall_175_accoustic", "zones": ["room_2", "guestroom"],                        "area": 7.2197 } // NE spine strip: the L-shaped guestroom wraps room_2's NE corner, (4.279 − 1.14 to hall) × 2.30
     ]
 }

--- a/src/estimate.rs
+++ b/src/estimate.rs
@@ -258,7 +258,7 @@ pub fn drive(
                 surf.tilt,
                 surf.azimuth,
             );
-            ss.set_flux(&mut u, surf.node, irradiance * surf.area);
+            ss.set_flux(&mut u, surf.node, irradiance * surf.area * surf.absorptance);
         }
         // Recorded underfloor heating (active backtest): inject each zone's hourly power at its
         // `heating` marker node(s), split equally when a zone's floor has several. Empty `heating_kw`

--- a/src/main.rs
+++ b/src/main.rs
@@ -510,7 +510,7 @@ fn demo_solar_gain(rcnet: &RcNetwork, ss: &StateSpace) -> anyhow::Result<()> {
     for surf in &rcnet.solar_surfaces {
         let irradiance =
             calculate_tilted_irradiance(lat, lon, &noon, clear, surf.tilt, surf.azimuth);
-        let flux = irradiance * surf.area;
+        let flux = irradiance * surf.area * surf.absorptance;
         total += flux;
         ss.set_flux(&mut u, surf.node, flux);
         println!(

--- a/src/model.rs
+++ b/src/model.rs
@@ -305,6 +305,10 @@ pub enum BoundaryType {
         /// A name that can be used to address the interface between the zone and
         /// the first layer.
         initial_marker: Option<String>,
+        /// Fraction of incident solar absorbed at the outer surface (1.0 = full absorption, the
+        /// default for opaque assemblies; lower for a ventilated/reflective one). Read into each
+        /// `SolarSurface` and multiplied into the injected solar flux.
+        solar_absorptance: f64,
     },
     Simple {
         name: String,
@@ -329,11 +333,13 @@ impl Arbitrary for BoundaryType {
                 "[a-z]*",
                 prop::collection::vec(BoundaryLayer::arbitrary_with(materials), 1..10),
                 prop::option::of("[a-z]*"),
+                0.0f64..=1.0,
             )
                 .prop_map(|tuple| BoundaryType::Layered {
                     name: tuple.0,
                     layers: tuple.1,
-                    initial_marker: tuple.2
+                    initial_marker: tuple.2,
+                    solar_absorptance: tuple.3,
                 }),
         ]
         .boxed()
@@ -491,12 +497,14 @@ mod as_loaded {
     pub enum BoundaryType {
         Layered {
             layers: Vec<BoundaryLayer>,
+            /// Fraction of incident solar absorbed at the outer surface (default 1.0). Lower it for a
+            /// reflective / ventilated assembly — e.g. a vented roof under black tiles, where most of
+            /// the tile heat is carried off by the air gap before it reaches the insulation.
+            #[serde(default)]
+            solar_absorptance: Option<f64>,
         },
         /// Simple boundaries don't have any mass!
-        Simple {
-            u: HeatTransfer,
-            g: Ratio,
-        },
+        Simple { u: HeatTransfer, g: Ratio },
     }
 
     impl BoundaryType {
@@ -506,7 +514,10 @@ mod as_loaded {
             materials: &HashMap<String, Rc<super::Material>>,
         ) -> anyhow::Result<super::BoundaryType> {
             Ok(match self {
-                BoundaryType::Layered { layers } => {
+                BoundaryType::Layered {
+                    layers,
+                    solar_absorptance,
+                } => {
                     let mut prev_is_marker = false;
                     let mut have_non_marker = false;
                     for layer in layers.iter() {
@@ -559,6 +570,7 @@ mod as_loaded {
                         name,
                         layers: out_layers,
                         initial_marker,
+                        solar_absorptance: solar_absorptance.unwrap_or(1.0),
                     }
                 }
                 BoundaryType::Simple { u, g } => super::BoundaryType::Simple { name, u, g },
@@ -688,6 +700,7 @@ mod tests {
                     thickness: Length::new::<meter>(2.0),
                 },
             ],
+            solar_absorptance: None,
         };
         let materials = converted_materials_hashmap();
         let output = input.convert("somename".to_string(), &materials).unwrap();
@@ -708,6 +721,7 @@ mod tests {
                     },
                 ],
                 initial_marker: Some("A DUCK!".into()),
+                solar_absorptance: 1.0,
             }
         );
     }
@@ -734,11 +748,14 @@ mod tests {
                 marker: "asdf".into(),
             },
         );
-        let input = as_loaded::BoundaryType::Layered { layers };
+        let input = as_loaded::BoundaryType::Layered {
+            layers,
+            solar_absorptance: None,
+        };
         let materials = converted_materials_hashmap();
         let output = input.convert("somename".to_string(), &materials).unwrap();
 
-        assert_matches!(output, BoundaryType::Layered { name: _, layers, initial_marker } => {
+        assert_matches!(output, BoundaryType::Layered { name: _, layers, initial_marker, solar_absorptance: _ } => {
             assert!(initial_marker.is_none());
             assert_eq!(layers.len(), 3);
             assert!(layers.iter().enumerate().all(|(j, l)| (j == (i - 1)) || l.following_marker.is_none()));
@@ -776,6 +793,7 @@ mod tests {
                     thickness: Length::new::<meter>(2.0),
                 },
             ],
+            solar_absorptance: None,
         };
         let materials = converted_materials_hashmap();
 
@@ -796,7 +814,10 @@ mod tests {
 
     #[test]
     fn convert_boundary_type_no_layers() {
-        let input = as_loaded::BoundaryType::Layered { layers: vec![] };
+        let input = as_loaded::BoundaryType::Layered {
+            layers: vec![],
+            solar_absorptance: None,
+        };
         let materials = converted_materials_hashmap();
 
         let message = format!(
@@ -815,6 +836,7 @@ mod tests {
     fn convert_boundary_type_only_marker() {
         let input = as_loaded::BoundaryType::Layered {
             layers: vec![as_loaded::BoundaryLayer::Marker { marker: "X".into() }],
+            solar_absorptance: None,
         };
         let materials = converted_materials_hashmap();
 
@@ -849,6 +871,7 @@ mod tests {
                     thickness: Length::new::<meter>(2.0),
                 },
             ],
+            solar_absorptance: None,
         };
         let materials = converted_materials_hashmap();
 
@@ -1540,7 +1563,7 @@ mod tests {
         );
 
         assert_eq!(model.boundaries.len(), 2);
-        assert_matches!(&model.boundaries[1].boundary_type.as_ref(), &BoundaryType::Layered{ name, layers: _, initial_marker: _ } => {
+        assert_matches!(&model.boundaries[1].boundary_type.as_ref(), &BoundaryType::Layered{ name, layers: _, initial_marker: _, .. } => {
             assert_eq!(name, "wall");
         });
     }

--- a/src/optimize/coordinator.rs
+++ b/src/optimize/coordinator.rs
@@ -224,7 +224,7 @@ fn known_thermal_inputs(
                 surf.tilt,
                 surf.azimuth,
             );
-            ss.set_flux(&mut u, surf.node, irradiance * surf.area);
+            ss.set_flux(&mut u, surf.node, irradiance * surf.area * surf.absorptance);
         }
         // Combined per-zone air-node flux: the constant internal gain plus any scheduled loads active
         // at this block's local time (their fitted magnitude × signed unit profile). Accumulate into

--- a/src/rc_network.rs
+++ b/src/rc_network.rs
@@ -208,7 +208,8 @@ impl From<&Model> for RcNetwork {
                 BoundaryType::Simple { name: _, u, g: _ } => {
                     // Window/door U-values already include the interior and exterior surface
                     // films (per ISO 10077), so model them as a single resistor R = 1/(U*A)
-                    // without adding convection again (see theory.md).
+                    // without adding convection again (see theory.md). Simple boundaries get no
+                    // solar gain, even when they inherit a parent's azimuth/tilt.
                     graph.add_edge(
                         z1,
                         z2,

--- a/src/rc_network.rs
+++ b/src/rc_network.rs
@@ -39,6 +39,9 @@ pub struct SolarSurface {
     pub azimuth: Angle,
     pub tilt: Angle,
     pub area: Area,
+    /// Fraction of incident solar absorbed (from the boundary type's `solar_absorptance`, default
+    /// 1.0). Multiplied into the injected flux so a reflective/ventilated surface gains less.
+    pub absorptance: f64,
 }
 
 #[derive(Clone, Debug)]
@@ -165,6 +168,7 @@ impl From<&Model> for RcNetwork {
                     name: _,
                     layers,
                     initial_marker,
+                    solar_absorptance,
                 } => {
                     let builder = LayeredBoundaryBuilder {
                         zone1_node: z1,
@@ -196,6 +200,7 @@ impl From<&Model> for RcNetwork {
                                 azimuth,
                                 tilt,
                                 area: boundary.area,
+                                absorptance: *solar_absorptance,
                             });
                         }
                     }
@@ -404,6 +409,7 @@ mod tests {
                     name: _,
                     layers,
                     initial_marker: _,
+                    ..
                 } => {
                     expected_node_count += layers.len() + 1;
                     expected_edge_count += layers.len() + 2;
@@ -441,6 +447,7 @@ mod tests {
                     name: _,
                     layers,
                     initial_marker: _,
+                    ..
                 } = boundary.boundary_type.as_ref()
                 {
                     Some(

--- a/src/state_space.rs
+++ b/src/state_space.rs
@@ -32,9 +32,10 @@ use uom::si::{
 
 use crate::rc_network::RcNetwork;
 
-/// Smallest heat capacity (J/K) used for a state node. Guards against division by zero
-/// for placeholder zero-volume zones; 1 J/K is a physically negligible thermal mass, so a
-/// floored node behaves as a fast-equilibrating massless node rather than producing NaNs.
+/// Smallest heat capacity (J/K) used for a state node. Guards against numerical instability
+/// from a near-zero computed capacity (e.g. a very thin boundary layer); 1 J/K is a physically
+/// negligible thermal mass, so a floored node behaves as a fast-equilibrating massless node
+/// rather than producing NaNs.
 const MIN_HEAT_CAPACITY: f64 = 1.0;
 
 /// Describes what a single column of the input vector `u` represents.


### PR DESCRIPTION
Builds out the physical building model and its thermal envelope.

- Solar-absorptance mechanism for opaque surfaces (the roof tuned to 0.2 for the ventilated tile gap).
- Measured first-floor thermal model with per-room heating limits and comfort bands.
- Complete attic envelope: NW gable (štít) + NE/SE eave walls + věnec, and a `ground_level_ceiling`
  type — a bare concrete slab where a ground-floor ceiling meets the attic directly (no heated room above).
- Owner-measured ceiling breakdowns (guestroom, upper hall, bathroom) replacing the footprint/cos35 estimates.
- First-floor exterior walls brought to the full 2.30 m clear height (2.10 m wall + 0.20 m věnec).
- Inter-floor tiling reconciled so every ground and first-floor room tiles its footprint.
- `docs/configuration.md` updated for the new boundary types and the zones[0]->zones[1] layer-direction convention.

Multi-agent reviewed clean (model + docs); 28.7 kWh demand, 204 tests pass, fmt/clippy clean.
Read-only shadow -- nothing actuates.
