### PR TITLE
Arm production controllers + config reconciliation + PV calibration fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Model predictive control of a house heating/cooling and possibly other things. T
  - [`docs/configuration.md`](docs/configuration.md) — how to write `model.json5` and `config.json5`: every field, its units, and tips (start here to describe a house).
  - [`theory.md`](theory.md) — the thermal RC-network physics behind the model.
  - [`docs/api.md`](docs/api.md) — the read-only monitoring/reporting API and dashboard.
- - [`docs/controllers.md`](docs/controllers.md) — the universal, language-agnostic controller protocol and the armed Growatt / Loxone / publisher controllers (in `controllers/`).
+ - [`docs/controllers.md`](docs/controllers.md) — the universal, language-agnostic controller protocol and the Growatt / Loxone / publisher controllers (in `controllers/`).
 
 
 # my materials

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Model predictive control of a house heating/cooling and possibly other things. T
  - [`docs/configuration.md`](docs/configuration.md) — how to write `model.json5` and `config.json5`: every field, its units, and tips (start here to describe a house).
  - [`theory.md`](theory.md) — the thermal RC-network physics behind the model.
  - [`docs/api.md`](docs/api.md) — the read-only monitoring/reporting API and dashboard.
- - [`docs/controllers.md`](docs/controllers.md) — the universal, language-agnostic controller protocol and the Growatt / heating reference controllers (in `controllers/`).
+ - [`docs/controllers.md`](docs/controllers.md) — the universal, language-agnostic controller protocol and the armed Growatt / Loxone / publisher controllers (in `controllers/`).
 
 
 # my materials

--- a/config.json5
+++ b/config.json5
@@ -113,7 +113,7 @@
     chargers: [
         {
             name: "tesla",
-            control: "modulating",     // loxone wallbox: the MPC can set rate + on/off (shadow only)
+            control: "modulating",     // loxone wallbox: the MPC sets rate + on/off via the armed loxone controller
             max_kw: 11.0,              // 3-phase 16 A; adjust to your wallbox
             min_kw: 1.4,               // ~6 A single-phase floor
             efficiency: 0.9,

--- a/config.json5
+++ b/config.json5
@@ -43,6 +43,24 @@
             guestroom:            { max_heat_kw: 3.0, t_min: 18.0, t_max: 23.0 },
         },
     },
+    // Scheduled (passive) thermal loads: appliances that add/remove heat at a zone's air node on a
+    // fixed civil-time schedule, outside the optimizer's control. Modelled as an extra flux in both the
+    // optimizer prediction and the calibration drive. `kind` fixes the sign; a known `power_w` is used
+    // as-is (omit it to have the calibration learn the magnitude). See docs/configuration.md.
+    // SUMMER ONLY: the water heat-pump is ducted to draw from technical_room (cooling it). In WINTER
+    // the plumbing switches to draw from OUTSIDE air, so it has no room effect ("outside" is an
+    // infinite reservoir in the model) — hence no winter window.
+    scheduled_loads: [
+        {
+            zone: "technical_room",
+            label: "water heat-pump (summer room-source)",
+            kind: "sink",                 // SWH-300IRE2: draws heat OUT of the room while running
+            power_w: 1600,                // ~1.6 kW room extraction (2.30 kW heating @ COP ~3)
+            windows: [
+                { months: [5,6,7,8,9], start: "10:00", end: "14:00" }, // summer only; runs to 65 C, up to 4 h
+            ],
+        },
+    ],
     // Reversible HVAC / air-conditioning (PLANNED — not yet installed). Each unit injects/removes
     // heat at the AIR node of the zones it serves: cooling above `t_cool`, air-heating below
     // `t_heat`, co-existing with the underfloor heating. A unit serving one zone is a room split; a

--- a/controllers/boiler/Cargo.toml
+++ b/controllers/boiler/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mpc-controller-boiler"
 version = "0.1.0"
 edition = "2021"
-description = "Controller: translates the MPC's controllable-load (boiler / hot-water tank) plan into a device command (stub — logged would-send only, no real protocol yet; dry-run draft)."
+description = "Controller: translates the MPC's controllable-load (boiler / hot-water tank) plan into a device command (stub — logged would-send only, no real protocol yet; dry-run)."
 
 [[bin]]
 name = "mpc-controller-boiler"

--- a/controllers/boiler/src/main.rs
+++ b/controllers/boiler/src/main.rs
@@ -1,7 +1,7 @@
 //! `mpc-controller-boiler` — the controllable-load (boiler / hot-water tank) path: the MPC's
 //! per-load on/off plan becomes a device command.
 //!
-//! **Stub / dry-run draft.** Subscribes the north command topic, translates the `Payload::Load`
+//! **Stub / dry-run.** Subscribes the north command topic, translates the `Payload::Load`
 //! channels into a logged would-send record ([`translate`]), and prints it. No real device protocol
 //! is wired yet (the Modbus boiler hasn't arrived), so it never actuates — even the `armed` path only
 //! logs, until [`translate`] grows a real datagram. A `valid_until` deadman either holds (the existing

--- a/controllers/ev/Cargo.toml
+++ b/controllers/ev/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mpc-controller-ev"
 version = "0.1.0"
 edition = "2021"
-description = "Controller: translates the MPC's per-charger EV plan into Loxone UDP virtual-input datagrams for the wallbox (dry-run draft)."
+description = "Controller: translates the MPC's per-charger EV plan into Loxone UDP virtual-input datagrams for the wallbox (legacy -- superseded by the unified loxone controller; dry-run)."
 
 [[bin]]
 name = "mpc-controller-ev"

--- a/controllers/growatt/Cargo.toml
+++ b/controllers/growatt/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mpc-controller-growatt"
 version = "0.1.0"
 edition = "2021"
-description = "Translates MPC battery intent into the Growatt MQTT command vocabulary (armed in production)."
+description = "Translates MPC battery intent into the Growatt MQTT command vocabulary."
 
 [[bin]]
 name = "mpc-controller-growatt"

--- a/controllers/growatt/Cargo.toml
+++ b/controllers/growatt/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mpc-controller-growatt"
 version = "0.1.0"
 edition = "2021"
-description = "Reference controller: translates MPC battery intent into the Growatt MQTT command vocabulary (dry-run draft)."
+description = "Translates MPC battery intent into the Growatt MQTT command vocabulary (armed in production)."
 
 [[bin]]
 name = "mpc-controller-growatt"

--- a/controllers/growatt/growatt.json5
+++ b/controllers/growatt/growatt.json5
@@ -1,5 +1,5 @@
 {
-    // Armed in production (loxone_smart_home's own Growatt control is OFF — never two controllers on one
+    // loxone_smart_home's own Growatt control is OFF (never two controllers on one
     // inverter). Actuation still needs BOTH armed:true AND the env MPC_CONTROLLER_ARM=i-understand-this-actuates.
     armed: true,
     mqtt: { host: "127.0.0.1", port: 1883, client_id: "mpc-controller-growatt" },

--- a/controllers/growatt/growatt.json5
+++ b/controllers/growatt/growatt.json5
@@ -1,7 +1,7 @@
 {
-    // DRY-RUN by default. loxone_smart_home owns the real inverter; this controller is a reference.
-    // Actuation needs BOTH armed:true AND the env MPC_CONTROLLER_ARM=i-understand-this-actuates.
-    armed: false,
+    // Armed in production (loxone_smart_home's own Growatt control is OFF — never two controllers on one
+    // inverter). Actuation still needs BOTH armed:true AND the env MPC_CONTROLLER_ARM=i-understand-this-actuates.
+    armed: true,
     mqtt: { host: "127.0.0.1", port: 1883, client_id: "mpc-controller-growatt" },
     controller_id: "growatt",
     control_topic: "mpc/control/growatt",     // north: where the publisher sends commands

--- a/controllers/growatt/src/config.rs
+++ b/controllers/growatt/src/config.rs
@@ -9,7 +9,8 @@ use crate::translate::TranslateCfg;
 #[derive(Debug, Clone, Deserialize)]
 pub struct GrowattConfig {
     /// `true` only *intends* to actuate; the south-side publish also requires the `MPC_CONTROLLER_ARM`
-    /// env token. Both keys are needed — neither alone touches the inverter. Default dry-run.
+    /// env token. Both keys are needed — neither alone touches the inverter. Struct default is `false`
+    /// (dry-run); the production `growatt.json5` sets `armed: true`.
     #[serde(default)]
     pub armed: bool,
     #[serde(default)]

--- a/controllers/growatt/src/main.rs
+++ b/controllers/growatt/src/main.rs
@@ -1,4 +1,4 @@
-//! `mpc-controller-growatt` — the battery/inverter controller. **Armed in production**
+//! `mpc-controller-growatt` — the battery/inverter controller
 //! (loxone_smart_home's own Growatt control is OFF — never two controllers on one inverter).
 //!
 //! Subscribes the north command topic, translates the battery intent into the Growatt MQTT command

--- a/controllers/growatt/src/main.rs
+++ b/controllers/growatt/src/main.rs
@@ -1,5 +1,5 @@
-//! `mpc-controller-growatt` — a **reference** controller (dry-run draft, never armed in practice:
-//! loxone_smart_home owns the real inverter).
+//! `mpc-controller-growatt` — the battery/inverter controller. **Armed in production**
+//! (loxone_smart_home's own Growatt control is OFF — never two controllers on one inverter).
 //!
 //! Subscribes the north command topic, translates the battery intent into the Growatt MQTT command
 //! vocabulary ([`translate`]), and — only when *both* the config `armed` flag and the

--- a/controllers/heating/Cargo.toml
+++ b/controllers/heating/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mpc-controller-heating"
 version = "0.1.0"
 edition = "2021"
-description = "Controller: translates MPC per-zone heating into Loxone UDP virtual-input datagrams (dry-run draft)."
+description = "Controller: translates MPC per-zone heating into Loxone UDP virtual-input datagrams (legacy -- superseded by the unified loxone controller; dry-run)."
 
 [[bin]]
 name = "mpc-controller-heating"

--- a/controllers/loxone/Cargo.toml
+++ b/controllers/loxone/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mpc-controller-loxone"
 version = "0.1.0"
 edition = "2021"
-description = "Controller: translates all Loxone-bound MPC decisions (heating, EV, …) into one Loxone UDP virtual-input datagram (dry-run default)."
+description = "Translates all Loxone-bound MPC decisions (heating, EV, …) into one Loxone UDP virtual-input datagram (armed in production)."
 
 [[bin]]
 name = "mpc-controller-loxone"

--- a/controllers/loxone/Cargo.toml
+++ b/controllers/loxone/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mpc-controller-loxone"
 version = "0.1.0"
 edition = "2021"
-description = "Translates all Loxone-bound MPC decisions (heating, EV, …) into one Loxone UDP virtual-input datagram (armed in production)."
+description = "Translates all Loxone-bound MPC decisions (heating, EV, …) into one Loxone UDP virtual-input datagram."
 
 [[bin]]
 name = "mpc-controller-loxone"

--- a/controllers/loxone/loxone.json5
+++ b/controllers/loxone/loxone.json5
@@ -1,8 +1,9 @@
 // mpc-controller-loxone — the unified Loxone UDP controller (heating, EV, future HVAC/boiler/shading).
-// Dry-run by default; actuating needs BOTH `armed: true` here AND
-// `MPC_CONTROLLER_ARM=i-understand-this-actuates` in the environment.
+// Armed in production; actuating needs BOTH `armed: true` here AND
+// `MPC_CONTROLLER_ARM=i-understand-this-actuates` in the environment (the two-key gate). Requires the
+// Loxone-side MPCActive watchdog + failsafe wiring below, and the Miniserver's own heating control OFF.
 {
-  armed: false,
+  armed: true,
   mqtt: { host: "127.0.0.1", port: 1883, client_id: "mpc-controller-loxone" },
   controller_id: "loxone",
   control_topic: "mpc/control/loxone",

--- a/controllers/loxone/loxone.json5
+++ b/controllers/loxone/loxone.json5
@@ -1,5 +1,5 @@
 // mpc-controller-loxone — the unified Loxone UDP controller (heating, EV, future HVAC/boiler/shading).
-// Armed in production; actuating needs BOTH `armed: true` here AND
+// Actuating needs BOTH `armed: true` here AND
 // `MPC_CONTROLLER_ARM=i-understand-this-actuates` in the environment (the two-key gate). Requires the
 // Loxone-side MPCActive watchdog + failsafe wiring below, and the Miniserver's own heating control OFF.
 {

--- a/controllers/loxone/src/config.rs
+++ b/controllers/loxone/src/config.rs
@@ -6,7 +6,8 @@ use std::path::Path;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct LoxoneControllerConfig {
-    /// Intends to actuate; the UDP send also requires the `MPC_CONTROLLER_ARM` env token. Default dry-run.
+    /// Intends to actuate; the UDP send also requires the `MPC_CONTROLLER_ARM` env token. Struct default
+    /// is `false` (dry-run); the production `loxone.json5` sets `armed: true`.
     #[serde(default)]
     pub armed: bool,
     #[serde(default)]

--- a/controllers/loxone/src/main.rs
+++ b/controllers/loxone/src/main.rs
@@ -1,4 +1,4 @@
-//! `mpc-controller-loxone` — the unified Loxone controller. **Armed in production.** Every Loxone-bound
+//! `mpc-controller-loxone` — the unified Loxone controller. Every Loxone-bound
 //! MPC decision (heating relays, EV power, future HVAC/boiler/shading) becomes one UDP virtual-input
 //! datagram, exactly as `mpc-controller-growatt` owns the inverter.
 //!

--- a/controllers/loxone/src/main.rs
+++ b/controllers/loxone/src/main.rs
@@ -1,6 +1,6 @@
-//! `mpc-controller-loxone` — the unified Loxone controller. Every Loxone-bound MPC decision (heating
-//! relays, EV power, future HVAC/boiler/shading) becomes one UDP virtual-input datagram, exactly as
-//! `mpc-controller-growatt` owns the inverter.
+//! `mpc-controller-loxone` — the unified Loxone controller. **Armed in production.** Every Loxone-bound
+//! MPC decision (heating relays, EV power, future HVAC/boiler/shading) becomes one UDP virtual-input
+//! datagram, exactly as `mpc-controller-growatt` owns the inverter.
 //!
 //! Subscribes the single `mpc/control/loxone` topic, prepends the `MPCActive` heartbeat gate,
 //! translates the generic key→value writes into one `key=value;…` datagram ([`translate`]), and —

--- a/controllers/publisher/publisher.json5
+++ b/controllers/publisher/publisher.json5
@@ -1,6 +1,6 @@
 {
-    // Armed in production (publishes plan-derived commands to the inert mpc/control/... MQTT namespace;
-    // the per-domain controllers below apply their own two-key gate before any device is touched).
+    // Publishes plan-derived commands to the inert mpc/control/... MQTT namespace;
+    // the per-domain controllers below apply their own two-key gate before any device is touched.
     armed: true,
     // The MPC's read-only plan endpoint to poll.
     mpc_url: "http://127.0.0.1:3000/api/plan/latest",

--- a/controllers/publisher/publisher.json5
+++ b/controllers/publisher/publisher.json5
@@ -1,6 +1,7 @@
 {
-    // Dry-run by default: logs the would-publish commands, publishes nothing to MQTT.
-    armed: false,
+    // Armed in production (publishes plan-derived commands to the inert mpc/control/... MQTT namespace;
+    // the per-domain controllers below apply their own two-key gate before any device is touched).
+    armed: true,
     // The MPC's read-only plan endpoint to poll.
     mpc_url: "http://127.0.0.1:3000/api/plan/latest",
     poll_seconds: 30,
@@ -11,7 +12,7 @@
     battery: { controller_id: "growatt", min_soc_kwh: 2.0, max_soc_kwh: 10.0 },
     // The unified Loxone controller — SUPERSEDES the `heating` + `ev` blocks (loading both is
     // rejected). Maps each plan field to its exact Loxone virtual-input key. The MPCActive gate is
-    // configured in controllers/loxone/loxone.example.json5, NOT here. See docs/controllers.md for the
+    // configured in controllers/loxone/loxone.json5, NOT here. See docs/controllers.md for the
     // Loxone-side wiring (digital-input pulse → Off-Delay watchdog).
     loxone: {
         controller_id: "loxone",

--- a/controllers/publisher/src/config.rs
+++ b/controllers/publisher/src/config.rs
@@ -18,8 +18,9 @@ pub struct PublisherConfig {
     /// the command expires and controllers hand control back. Keep it a small multiple of the poll.
     #[serde(default = "default_deadman_seconds")]
     pub deadman_seconds: i64,
-    /// `true` = publish to MQTT; `false` (default) = dry-run, log only. (Publishing only touches the
-    /// inert `mpc/control/...` namespace; hardware actuation is a separate arm on the controllers.)
+    /// `true` = publish to MQTT; `false` = dry-run, log only. Struct default is `false`; the production
+    /// `publisher.json5` sets `armed: true`. (Publishing only touches the inert `mpc/control/...`
+    /// namespace; hardware actuation is a separate two-key arm on the per-domain controllers.)
     #[serde(default)]
     pub armed: bool,
     #[serde(default)]
@@ -75,7 +76,7 @@ pub struct BatteryPub {
 pub struct HeatingPub {
     #[serde(default = "default_heating_id")]
     pub controller_id: String,
-    /// A zone is "on" when its planned power exceeds this (kW) — mirrors the shadow's relay threshold.
+    /// A zone is "on" when its planned power exceeds this (kW) — mirrors the MPC's relay threshold.
     #[serde(default = "default_on_threshold_kw")]
     pub on_threshold_kw: f64,
 }

--- a/controllers/publisher/src/main.rs
+++ b/controllers/publisher/src/main.rs
@@ -3,8 +3,8 @@
 //! Polls the MPC's **read-only** `/api/plan/latest`, maps the coming-block plan into per-controller
 //! [`controller_protocol::ControlCommand`]s, and republishes them to the inert `mpc/control/...` MQTT
 //! namespace. This keeps the MPC binary itself free of any MQTT dependency — its read-only guarantee
-//! stays structural. **Armed in production** (publishes to the inert `mpc/control/...` namespace; gated
-//! by its own `armed` flag — the per-domain controllers downstream apply the two-key hardware gate).
+//! stays structural. It publishes to the inert `mpc/control/...` namespace, gated
+//! by its own `armed` flag — the per-domain controllers downstream apply the two-key hardware gate.
 //! With `armed: false` it is dry-run: logs the would-publish JSON, touches nothing.
 
 mod build;

--- a/controllers/publisher/src/main.rs
+++ b/controllers/publisher/src/main.rs
@@ -3,7 +3,9 @@
 //! Polls the MPC's **read-only** `/api/plan/latest`, maps the coming-block plan into per-controller
 //! [`controller_protocol::ControlCommand`]s, and republishes them to the inert `mpc/control/...` MQTT
 //! namespace. This keeps the MPC binary itself free of any MQTT dependency — its read-only guarantee
-//! stays structural. **Dry-run by default** (logs the would-publish JSON, touches nothing).
+//! stays structural. **Armed in production** (publishes to the inert `mpc/control/...` namespace; gated
+//! by its own `armed` flag — the per-domain controllers downstream apply the two-key hardware gate).
+//! With `armed: false` it is dry-run: logs the would-publish JSON, touches nothing.
 
 mod build;
 mod config;

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-# Minimal image for the read-only shadow brain, run alongside the loxone stack with
+# Minimal image for the read-only brain, run alongside the loxone stack with
 # `--restart unless-stopped` for crash + reboot persistence.
 #
 # The binary is a static musl build, so a tiny base works. Build it first on the host:
@@ -9,10 +9,10 @@
 #
 # Run on the loxone `caddy_net` network so it reaches influx by service name; the binary reads
 # INFLUXDB_TOKEN, INFLUX_HOST (-> http://influxdb:8086) and MPC_BIND (-> 0.0.0.0) from the env:
-#   docker run -d --name mpc-shadow --restart unless-stopped --network caddy_net \
+#   docker run -d --name mpc-brain --restart unless-stopped --network caddy_net \
 #       -e INFLUX_HOST=http://influxdb:8086 -e MPC_BIND=0.0.0.0 \
 #       -e INFLUXDB_TOKEN="$(grep '^INFLUXDB_TOKEN=' .../loxone_smart_home/.env | cut -d= -f2-)" \
-#       -p 127.0.0.1:3000:3000 mpc-shadow
+#       -p 127.0.0.1:3000:3000 mpc-brain
 FROM alpine:3.20
 WORKDIR /app
 COPY mpc_home_control model.json5 config.json5 ./

--- a/deploy/grafana/mpc-brain-dashboard.json
+++ b/deploy/grafana/mpc-brain-dashboard.json
@@ -2,8 +2,8 @@
   "__inputs": [
     {
       "name": "DS_INFINITY",
-      "label": "Infinity (mpc-shadow)",
-      "description": "Infinity datasource with base URL set to the mpc-shadow API (e.g. http://mpc-shadow:3000).",
+      "label": "Infinity (mpc-brain)",
+      "description": "Infinity datasource with base URL set to the mpc-brain API (e.g. http://mpc-brain:3000).",
       "type": "datasource",
       "pluginId": "yesoreyeram-infinity-datasource",
       "pluginName": "Infinity"
@@ -13,9 +13,9 @@
     { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
     { "type": "datasource", "id": "yesoreyeram-infinity-datasource", "name": "Infinity", "version": "1.0.0" }
   ],
-  "title": "MPC Shadow",
-  "uid": "mpc-shadow",
-  "tags": ["mpc", "shadow"],
+  "title": "MPC Brain",
+  "uid": "mpc-brain",
+  "tags": ["mpc", "brain"],
   "schemaVersion": 39,
   "version": 1,
   "editable": true,
@@ -94,7 +94,7 @@
     },
     {
       "id": 4,
-      "title": "Shadow vs loxone — mode agreement",
+      "title": "MPC vs loxone — mode agreement",
       "type": "stat",
       "gridPos": { "h": 4, "w": 6, "x": 12, "y": 8 },
       "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },

--- a/deploy/healthcheck.sh
+++ b/deploy/healthcheck.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-# One-shot health verdict for the armed MPC control stack (brain + publisher + growatt).
+# One-shot health verdict for the armed MPC control stack (brain + publisher + growatt + loxone).
 # Prints "OK | <summary>" or "ANOMALY:<flags> | <summary>". Used by the monitoring watchdog.
 D="${DOCKER:-/usr/local/bin/docker}"
 LAN="${MPC_LAN_URL:-http://127.0.0.1:3000}"   # override per host (the brain's published API URL)
-N=$("$D" ps --filter name=mpc-brain --filter name=mpc-publisher --filter name=mpc-growatt --format '{{.Names}}' | wc -l | tr -d ' ')
+N=$("$D" ps --filter name=mpc-brain --filter name=mpc-publisher --filter name=mpc-growatt --filter name=mpc-loxone --format '{{.Names}}' | wc -l | tr -d ' ')
 RZ=$(curl -s -m8 -o /dev/null -w '%{http_code}' "$LAN/readyz")
 PLAN=$(curl -s -m8 "$LAN/api/plan/latest")
 DEC=$(printf '%s' "$PLAN" | python3 "$(dirname "$0")/parse_plan.py")
@@ -12,6 +12,7 @@ SOC=$(echo "$DEC" | cut -d'|' -f3); CHG=$(echo "$DEC" | cut -d'|' -f4); BAD=$(ec
 GERR=$("$D" logs --since 11m mpc-growatt 2>&1 | grep -ciE 'GAVE UP|panic')
 PFAIL=$("$D" logs --since 11m mpc-publisher 2>&1 | grep -ciE 'poll.*failed|panic')
 ACKF=$("$D" logs --since 11m mpc-growatt 2>&1 | grep -c '"success":false')
+LERR=$("$D" logs --since 11m mpc-loxone 2>&1 | grep -ciE 'GAVE UP|panic')
 # Live inverter telemetry: confirm the plan is actually being executed (e.g. discharging when told to).
 TEL=$(timeout 8 "$D" exec mosquitto mosquitto_sub -t energy/solar -C 1 2>/dev/null | python3 -c "import sys,json
 try:
@@ -25,13 +26,14 @@ STALL=0
 case "$SLOT" in discharge_to_grid)
   case "$DIS" in 0|0.0) case "$SOC" in 2.[0-7]*|2|1.*|0.*) ;; *) STALL=1;; esac;; esac;; esac
 # `topoff` (charge_from_grid at ~full SoC) is informational: the stop-SoC caps the charge, no overcharge.
-SUMMARY="containers=$N readyz=$RZ slot=$SLOT soc=$SOC chg=$CHG dis_w=$DIS exp_w=$EXP ph=$PH gerr=$GERR pfail=$PFAIL ackfail=$ACKF topoff=$BAD"
+SUMMARY="containers=$N readyz=$RZ slot=$SLOT soc=$SOC chg=$CHG dis_w=$DIS exp_w=$EXP ph=$PH gerr=$GERR pfail=$PFAIL ackfail=$ACKF lerr=$LERR topoff=$BAD"
 A=""
-[ "$N" = "3" ] || A="$A containers_down"
+[ "$N" = "4" ] || A="$A containers_down"
 [ "$RZ" = "200" ] || A="$A readyz"
 [ "$PH" = "0" ] || A="$A placeholders"
 [ "$GERR" = "0" ] || A="$A growatt_giveup_or_panic"
 [ "$PFAIL" -lt 2 ] || A="$A publisher_failures"   # tolerate a single transient poll-miss (deadman has 120s headroom); trip on 2+
 [ "$ACKF" = "0" ] || A="$A inverter_ack_failure"
+[ "$LERR" = "0" ] || A="$A loxone_giveup_or_panic"
 [ "$STALL" = "0" ] || A="$A discharge_not_executing"
 if [ -n "$A" ]; then echo "ANOMALY:$A | $SUMMARY"; else echo "OK | $SUMMARY"; fi

--- a/deploy/healthcheck.sh
+++ b/deploy/healthcheck.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# One-shot health verdict for the armed MPC control stack (brain + publisher + growatt + loxone).
+# One-shot health verdict for the MPC control stack (brain + publisher + growatt + loxone).
 # Prints "OK | <summary>" or "ANOMALY:<flags> | <summary>". Used by the monitoring watchdog.
 D="${DOCKER:-/usr/local/bin/docker}"
 LAN="${MPC_LAN_URL:-http://127.0.0.1:3000}"   # override per host (the brain's published API URL)

--- a/deploy/run-loxone.sh
+++ b/deploy/run-loxone.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Run the unified Loxone controller — subscribes mpc/control/loxone and emits the key=value;… UDP
+# datagram (prepended with the MPCActive heartbeat) to the Miniserver. Actuates (sends UDP) ONLY with
+# BOTH config armed:true AND MPC_CONTROLLER_ARM=i-understand-this-actuates. Dry-run otherwise: logs the
+# would-send datagram, sends nothing.
+#
+#   sh ./run-loxone.sh                                               # dry-run
+#   MPC_CONTROLLER_ARM=i-understand-this-actuates sh ./run-loxone.sh # armed → sends UDP to Loxone
+#
+# Before arming, the Loxone side must be wired (MPCActive digital-input pulse → Off-Delay watchdog →
+# ALIVE; every MPC-driven VI gated `value AND ALIVE`; failsafe hold) and the Miniserver's own heating
+# control turned OFF — see docs/controllers.md.
+#
+# DEPLOY: this is a template — copy it together with the controller's config (controllers/loxone/
+# loxone.json5) into one directory (e.g. the server's mpc-docker/ctrl/) and run it from there. DIR
+# defaults to the script's own directory and MUST hold loxone.json5 (it is bind-mounted into the
+# container); run-growatt.sh / run-publisher.sh follow the same pattern. Override DOCKER / DIR per host.
+DOCKER="${DOCKER:-docker}"
+DIR="${DIR:-$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)}"
+ARM_ENV=""
+if [ -n "$MPC_CONTROLLER_ARM" ]; then
+  ARM_ENV="-e MPC_CONTROLLER_ARM=$MPC_CONTROLLER_ARM"
+  echo "run-loxone.sh: ARM token present — controller will SEND UDP IF its config has armed:true."
+else
+  echo "run-loxone.sh: no ARM token — dry-run (logs the would-send datagram, sends nothing)."
+fi
+$DOCKER rm -f mpc-loxone 2>/dev/null
+# shellcheck disable=SC2086
+$DOCKER run -d --name mpc-loxone --restart unless-stopped \
+  --network caddy_net \
+  $ARM_ENV \
+  -v "$DIR/loxone.json5:/app/config.json5:ro" \
+  mpc-loxone

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,8 +1,8 @@
 # Monitoring & reporting API
 
-The shadow server (`cargo run -- serve`) exposes a **read-only** JSON API on `:3000`
+The MPC brain (`cargo run -- serve`) exposes a **read-only** JSON API on `:3000`
 (`MPC_BIND=0.0.0.0` to expose from a container). It never writes InfluxDB (only its own
-forecast-snapshot file) and never actuates.
+forecast-snapshot file) and never actuates (the armed controllers actuate separately).
 
 `GET /` serves the **dashboard** — a self-contained multi-screen web app (Home + Energy, Heating,
 Model, System), embedded in the binary (ECharts vendored, works offline), driven entirely
@@ -46,7 +46,7 @@ it in the envelope above.
 - **`GET /api/state`** — current per-zone air temperature: `{ zones: [{zone, temp_c}] }`. The model estimate (a drive over recent history to recover the unobservable wall/slab masses) **re-anchored to each zone's latest measured reading**, so it reflects disturbances the model can't see (e.g. windows left open overnight) rather than the free-running prediction.
 - **`GET /api/zones/series?hours=N`** — recent **measured** per-zone air-temperature series for the comfort-grid sparklines (default 24 h, clamped 1–48), 30-minute means: `[{ zone, series: [[iso, °C], …] }]`. Zones with no data are omitted.
 - **`GET /api/plan`** — on-demand whole-house plan (recomputes). Aggregates (cost EUR/CZK, grid/heating/cooling/HVAC-heating/battery kWh, PV curtailed, calibration scale, `placeholder_inputs`), the immediate `first_step`, and the per-block `timeline` (below). HVAC fields (`cooling_kwh`, `hvac_heating_kwh`, and the per-block `cool_kw`/`hvac_heat_kw` maps) are `0`/empty unless an `hvac` block is configured.
-- **`GET /api/plan/latest`** — the latest plan published by the shadow loop (no recompute; `503` while warming up). `data` is the same plan shape as `/api/plan` (the envelope's `computed_at` is when it was published).
+- **`GET /api/plan/latest`** — the latest plan published by the MPC loop (no recompute; `503` while warming up). `data` is the same plan shape as `/api/plan` (the envelope's `computed_at` is when it was published).
 - **`GET /api/plan/timeline`** — just the latest plan's per-block rows (the chart-ready shape):
 
 ```json
@@ -99,10 +99,10 @@ Environment:
 
 ## Grafana
 
-The server already runs Grafana (`loxone-db-grafana`). Because the shadow is read-only it can't write
+The server already runs Grafana (`loxone-db-grafana`). Because the brain is read-only it can't write
 InfluxDB, so drive Grafana from these endpoints with the **Infinity** datasource
 (`yesoreyeram-infinity-datasource`): type `JSON`, source `URL`, and a root selector of `data` (or
 `data.timeline`) to step into the envelope. A starter dashboard is in
-[`deploy/grafana/mpc-shadow-dashboard.json`](../deploy/grafana/mpc-shadow-dashboard.json) — import it
-and point the Infinity datasource at `http://mpc-shadow:3000` (on the `caddy_net` network) or the
+[`deploy/grafana/mpc-brain-dashboard.json`](../deploy/grafana/mpc-brain-dashboard.json) — import it
+and point the Infinity datasource at `http://mpc-brain:3000` (on the `caddy_net` network) or the
 published `127.0.0.1:3000`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 The MPC brain (`cargo run -- serve`) exposes a **read-only** JSON API on `:3000`
 (`MPC_BIND=0.0.0.0` to expose from a container). It never writes InfluxDB (only its own
-forecast-snapshot file) and never actuates (the armed controllers actuate separately).
+forecast-snapshot file) and never actuates (the controllers actuate separately).
 
 `GET /` serves the **dashboard** — a self-contained multi-screen web app (Home + Energy, Heating,
 Model, System), embedded in the binary (ECharts vendored, works offline), driven entirely

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -386,7 +386,7 @@ existing scheduled load is unchanged — the plan is byte-identical until you op
 | Key | Default | Meaning |
 |---|---|---|
 | `consumption_history_days` | 30 | trailing window to train the consumption model |
-| `mpc_tick_minutes` | 60 | how often the shadow loop re-plans (also the `/readyz` staleness threshold) |
+| `mpc_tick_minutes` | 60 | how often the MPC loop re-plans (also the `/readyz` staleness threshold) |
 | `internal_gain_window_days` | 7 | window for the live internal-gain re-fit |
 | `internal_gain_recalibrate_hours` | 24 | re-fit cadence (0 disables) |
 | `forecast_snapshot_minutes` | 60 | forward-prediction snapshot cadence (0 disables) |

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -6,9 +6,15 @@ HVAC, …) and hardware (Growatt, Loxone, future HCSC). Each speaks its **own** 
 **single, universal, language-agnostic protocol** to the MPC, so a controller can be written in Rust,
 Python, or anything.
 
-> **Status: drafts, not wired on.** The controllers here are working *dry-run* reference
-> implementations. Nothing is deployed or armed; the live house is driven by `loxone_smart_home` as
-> before. Two independent gates (config + env) stand between this code and any hardware.
+> **Status: armed in production.** The `growatt` (battery/inverter), `loxone` (heating + EV UDP edge),
+> and `publisher` (north bridge) controllers run armed on the house server; `heating`/`ev` (superseded
+> by the unified `loxone`) and `boiler` (stub) stay dry-run. Each **hardware** controller (`growatt`,
+> `loxone`) needs BOTH keys before it touches a device — the config `armed: true` flag **and** the
+> `MPC_CONTROLLER_ARM=i-understand-this-actuates` env token. The `publisher` only bridges plans onto the
+> inert `mpc/control/...` MQTT namespace, so it gates on its `armed` flag alone; nothing reaches hardware
+> without a downstream controller's two keys. Before arming the `loxone` controller the Loxone-side wiring
+> (the `MPCActive` watchdog + `failsafe: hold`, see below) must be in place and the Miniserver's own
+> heating control turned OFF, so the MPC is the single master.
 
 ## Architecture
 
@@ -16,18 +22,19 @@ Python, or anything.
 mpc_home_control (read-only, UNCHANGED) ── GET /api/plan/latest ──▶  (HTTP JSON)
         │  (read-only HTTP)
         ▼
-mpc-plan-publisher  (north bridge; dry-run default)
+mpc-plan-publisher  (north bridge; armed)
    poll the plan → ControlCommand (with a TTL) → publish MQTT  mpc/control/<ctrl>  (retained + LWT)
-        │  (MQTT — an inert namespace nothing live consumes)
-        ├──▶ mpc-controller-growatt  ─ translate ▶  energy/solar/command/...   (Growatt MQTT; never armed)
+        │  (MQTT — the mpc/control namespace the armed hardware controllers consume)
+        ├──▶ mpc-controller-growatt  ─ translate ▶  energy/solar/command/...   (Growatt MQTT; ARMED — loxone's own Growatt control off)
         ├──▶ mpc-controller-heating  ─ translate ▶  UDP key=value ▶ Loxone Miniserver:4000  (NEW virtual inputs)
         ├──▶ mpc-controller-ev       ─ translate ▶  UDP key=value ▶ Loxone Miniserver:4000  (wallbox virtual inputs)
         └──▶ mpc-controller-loxone   ─ translate ▶  UDP key=value ▶ Loxone Miniserver:4000  (UNIFIED heating+EV+future; supersedes the two above)
 ```
 
 The MPC binary has **no MQTT dependency** — it only serves its existing read-only API. The publisher
-is the one component that puts commands on MQTT, into the new `mpc/control/...` namespace that no live
-system consumes. The controllers translate that into the real device protocols, but only when armed.
+is the one component that puts commands on MQTT, into the `mpc/control/...` namespace that the armed
+hardware controllers consume. They translate that into the real device protocols, each gated by its
+own two-key arm.
 This keeps the MPC's read-only guarantee **structural** (`cargo tree -p mpc_home_control` contains no
 `rumqttc`).
 
@@ -110,13 +117,13 @@ state, device telemetry, and the `actions` it took:
 Each `PlannedAction` is the audit record — computed and logged in both modes, with `published: false`
 in dry-run and `true` after an armed send.
 
-## The two reference controllers
+## The controllers
 
-### Growatt (`mpc-controller-growatt`) — reference draft, never armed
+### Growatt (`mpc-controller-growatt`) — armed
 
 Translates a `battery` command into the real Growatt MQTT vocabulary (`energy/solar/command/...`).
-loxone_smart_home owns the live inverter, so this is a reference; arming it would conflict (it is a
-mutually-exclusive cut-over, never coexistence). The translation:
+loxone_smart_home's own Growatt control is OFF, so the MPC controller now owns the inverter — a
+mutually-exclusive cut-over (never two controllers on one inverter). The translation:
 
 | `slot` | Growatt MQTT |
 |---|---|
@@ -136,10 +143,10 @@ enabled (mirrors loxone's `ensure_exclusive`). Plus the orthogonal `export/enabl
 `energy/solar` subscription (fresher than the command's `soc_kwh`). On deadman expiry it reverts to
 `regular` (or `hold`).
 
-> **Not armable as-is** (see issue #23): the controller still needs a
-> command-ack/retry loop on `energy/solar/result`, a broker-down actuation gate, and the optimizer's
-> reserve-SoC floor before it can safely replace loxone. The payload/exclusivity/powerRate fixes
-> above are landed; the rest is tracked separately.
+> **Armed** (see issue #23): the command-ack/retry loop on `energy/solar/result`, the reserve-SoC floor,
+> and the payload/exclusivity/powerRate fixes are landed. A dedicated broker-down actuation gate is still
+> tracked as a refinement — today the `valid_until` deadman (revert to `regular` on command silence) is
+> the broker-down backstop.
 
 ### Heating (`mpc-controller-heating`) — legacy single-zone path (superseded)
 
@@ -200,7 +207,7 @@ yet, so `translate` produces only a logged **would-send** record (`stub://<targe
 complete; when the Modbus boiler arrives, only `translate.rs` grows the real datagram. Config:
 [`controllers/boiler/boiler.example.json5`](../controllers/boiler/boiler.example.json5).
 
-### Loxone (`mpc-controller-loxone`) — the unified Loxone UDP path
+### Loxone (`mpc-controller-loxone`) — the unified Loxone UDP path, armed
 
 One controller that owns the UDP edge to the Miniserver: **all** Loxone-bound actuation (heating
 relays, EV power, future HVAC/boiler/shading) in one `key=value;…` datagram, exactly as
@@ -225,7 +232,7 @@ loxone: {
 **The `MPCActive` gate (failsafe).** The controller prepends `MPCActive=1` to every datagram and
 re-sends the live datagram on a **10 s heartbeat**, so a dead/disarmed brain stops the pulse train.
 `AND` every MPC-driven output on the Loxone side with an "alive" signal derived from `MPCActive`, so a
-silent brain reverts the whole house to native control. Two-key arm, deadman, dry-run default,
+silent brain reverts the whole house to native control. Two-key arm (armed in production), deadman,
 status/health — all as every other controller.
 
 #### Loxone-side wiring (digital-input pulse → Off-Delay watchdog)
@@ -253,7 +260,7 @@ MPCActive  (UDP virtual input, "Use as digital input" ✓)  →  Off Delay (30 s
   the Off Delay — worst case ≈ `deadman_seconds` + 30 s. Lower `deadman_seconds` (keep it ≥ ~3× the
   poll) for a faster brain-death fallback.
 
-Config: [`controllers/loxone/loxone.example.json5`](../controllers/loxone/loxone.example.json5); full
+Config: [`controllers/loxone/loxone.json5`](../controllers/loxone/loxone.json5); full
 design + the virtual-input naming scheme in [loxone-controller-plan.md](loxone-controller-plan.md).
 
 ## Dry-run, arming, and the deadman (safety)
@@ -281,25 +288,28 @@ Any program that can speak MQTT + JSON can be a controller. It must:
 A complete ~40-line example is in
 [`controllers/examples/python_controller_stub.py`](../controllers/examples/python_controller_stub.py).
 
-## Running the drafts (local dry-run)
+## Running the pipeline locally (dry-run)
 
-Everything stays dry-run and points at a **local** broker — never the house broker or loxone:
+The committed configs are **armed** (`armed: true`), but the hardware controllers also need the
+`MPC_CONTROLLER_ARM` env token — so **with that token unset they stay dry-run**, even at `armed: true`.
+For a safe local run, point at a **local** broker (never the house broker or loxone) and **do not**
+export `MPC_CONTROLLER_ARM`:
 
 ```bash
 # 1) a local broker (e.g. `mosquitto`), and the MPC serving its read-only API on :3000
 cargo run -- serve
 
-# 2) the publisher (dry-run logs the would-publish commands)
+# 2) the publisher (armed → publishes to the LOCAL broker's mpc/control namespace)
 cargo run -p mpc-plan-publisher -- controllers/publisher/publisher.json5
 
-# 3) the controllers (dry-run log the would-send device messages)
+# 3) the controllers — dry-run here because MPC_CONTROLLER_ARM is unset (log the would-send messages)
 cargo run -p mpc-controller-growatt -- controllers/growatt/growatt.json5
 cargo run -p mpc-controller-heating -- controllers/heating/heating.json5
 cargo run -p mpc-controller-ev      -- controllers/ev/ev.example.json5
 cargo run -p mpc-controller-boiler  -- controllers/boiler/boiler.example.json5
-cargo run -p mpc-controller-loxone  -- controllers/loxone/loxone.example.json5
+cargo run -p mpc-controller-loxone  -- controllers/loxone/loxone.json5
 ```
 
-With the publisher armed against a local broker (and the controllers still dry-run), you can watch the
-whole pipeline — the publisher posting `mpc/control/...`, each controller logging the exact device
-messages it *would* send — without anything reaching real hardware.
+With `MPC_CONTROLLER_ARM` unset (and a local broker), you can watch the whole pipeline — the publisher
+posting `mpc/control/...`, each hardware controller logging the exact device messages it *would* send —
+without anything reaching real hardware.

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -6,8 +6,8 @@ HVAC, …) and hardware (Growatt, Loxone, future HCSC). Each speaks its **own** 
 **single, universal, language-agnostic protocol** to the MPC, so a controller can be written in Rust,
 Python, or anything.
 
-> **Status: armed in production.** The `growatt` (battery/inverter), `loxone` (heating + EV UDP edge),
-> and `publisher` (north bridge) controllers run armed on the house server; `heating`/`ev` (superseded
+> **Two-key actuation.** The `growatt` (battery/inverter), `loxone` (heating + EV UDP edge),
+> and `publisher` (north bridge) controllers actuate the house; `heating`/`ev` (superseded
 > by the unified `loxone`) and `boiler` (stub) stay dry-run. Each **hardware** controller (`growatt`,
 > `loxone`) needs BOTH keys before it touches a device — the config `armed: true` flag **and** the
 > `MPC_CONTROLLER_ARM=i-understand-this-actuates` env token. The `publisher` only bridges plans onto the
@@ -22,17 +22,17 @@ Python, or anything.
 mpc_home_control (read-only, UNCHANGED) ── GET /api/plan/latest ──▶  (HTTP JSON)
         │  (read-only HTTP)
         ▼
-mpc-plan-publisher  (north bridge; armed)
+mpc-plan-publisher  (north bridge)
    poll the plan → ControlCommand (with a TTL) → publish MQTT  mpc/control/<ctrl>  (retained + LWT)
-        │  (MQTT — the mpc/control namespace the armed hardware controllers consume)
-        ├──▶ mpc-controller-growatt  ─ translate ▶  energy/solar/command/...   (Growatt MQTT; ARMED — loxone's own Growatt control off)
+        │  (MQTT — the mpc/control namespace the hardware controllers consume)
+        ├──▶ mpc-controller-growatt  ─ translate ▶  energy/solar/command/...   (Growatt MQTT; loxone's own Growatt control off)
         ├──▶ mpc-controller-heating  ─ translate ▶  UDP key=value ▶ Loxone Miniserver:4000  (NEW virtual inputs)
         ├──▶ mpc-controller-ev       ─ translate ▶  UDP key=value ▶ Loxone Miniserver:4000  (wallbox virtual inputs)
         └──▶ mpc-controller-loxone   ─ translate ▶  UDP key=value ▶ Loxone Miniserver:4000  (UNIFIED heating+EV+future; supersedes the two above)
 ```
 
 The MPC binary has **no MQTT dependency** — it only serves its existing read-only API. The publisher
-is the one component that puts commands on MQTT, into the `mpc/control/...` namespace that the armed
+is the one component that puts commands on MQTT, into the `mpc/control/...` namespace that the
 hardware controllers consume. They translate that into the real device protocols, each gated by its
 own two-key arm.
 This keeps the MPC's read-only guarantee **structural** (`cargo tree -p mpc_home_control` contains no
@@ -119,7 +119,7 @@ in dry-run and `true` after an armed send.
 
 ## The controllers
 
-### Growatt (`mpc-controller-growatt`) — armed
+### Growatt (`mpc-controller-growatt`)
 
 Translates a `battery` command into the real Growatt MQTT vocabulary (`energy/solar/command/...`).
 loxone_smart_home's own Growatt control is OFF, so the MPC controller now owns the inverter — a
@@ -143,7 +143,7 @@ enabled (mirrors loxone's `ensure_exclusive`). Plus the orthogonal `export/enabl
 `energy/solar` subscription (fresher than the command's `soc_kwh`). On deadman expiry it reverts to
 `regular` (or `hold`).
 
-> **Armed** (see issue #23): the command-ack/retry loop on `energy/solar/result`, the reserve-SoC floor,
+> **Implemented** (see issue #23): the command-ack/retry loop on `energy/solar/result`, the reserve-SoC floor,
 > and the payload/exclusivity/powerRate fixes are landed. A dedicated broker-down actuation gate is still
 > tracked as a refinement — today the `valid_until` deadman (revert to `regular` on command silence) is
 > the broker-down backstop.
@@ -207,7 +207,7 @@ yet, so `translate` produces only a logged **would-send** record (`stub://<targe
 complete; when the Modbus boiler arrives, only `translate.rs` grows the real datagram. Config:
 [`controllers/boiler/boiler.example.json5`](../controllers/boiler/boiler.example.json5).
 
-### Loxone (`mpc-controller-loxone`) — the unified Loxone UDP path, armed
+### Loxone (`mpc-controller-loxone`) — the unified Loxone UDP path
 
 One controller that owns the UDP edge to the Miniserver: **all** Loxone-bound actuation (heating
 relays, EV power, future HVAC/boiler/shading) in one `key=value;…` datagram, exactly as
@@ -232,7 +232,7 @@ loxone: {
 **The `MPCActive` gate (failsafe).** The controller prepends `MPCActive=1` to every datagram and
 re-sends the live datagram on a **10 s heartbeat**, so a dead/disarmed brain stops the pulse train.
 `AND` every MPC-driven output on the Loxone side with an "alive" signal derived from `MPCActive`, so a
-silent brain reverts the whole house to native control. Two-key arm (armed in production), deadman,
+silent brain reverts the whole house to native control. Two-key arm, deadman,
 status/health — all as every other controller.
 
 #### Loxone-side wiring (digital-input pulse → Off-Delay watchdog)

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -50,7 +50,7 @@ prices, raw rows) the rest of the readers already use.
 | **MQTT** | `adapters/mqtt-bridge` (→ Influx) or `adapters/mqtt-source` (→ HTTP) | **sidecar → pull** | never links into the MPC |
 
 Postgres and HTTP are pure-Rust and musl-friendly (no C / OpenSSL), so they cross-build for the
-Synology shadow exactly like the rest of the binary.
+Synology MPC brain exactly like the rest of the binary.
 
 ### Secrets stay in the environment
 

--- a/docs/ev.md
+++ b/docs/ev.md
@@ -5,7 +5,7 @@ and a deadline. The optimizer schedules the charge toward the target at lowest c
 with the home battery, solar, heating, and HVAC in the one LP — but **only while the car is
 controllable on our own wallbox**. The brain stays **read-only** (the plan is a recommendation); a
 controller actuates only when explicitly armed behind its two-key gate — the unified `loxone` controller
-is now armed in production and drives EV charging downstream.
+drives EV charging downstream.
 
 EV support activates only when at least one charger is configured — the dashboard's EV screen and the
 `/api/ev*` endpoints appear conditionally (via `/api/capabilities`).
@@ -147,12 +147,12 @@ Conditional on `has_ev`. Per charger it shows the status badge (on our wallbox /
 / driving), the car SoC → target, the first-block charge power, the planned session energy, and a
 **source-stacked** charge-schedule chart (solar / grid / battery → car per 15-min block). The
 **strategy / target / deadline** controls `POST` to the preference endpoint, and the next plan reflects
-them. The dashboard itself only sets preferences and shows the plan; the armed loxone controller drives
+them. The dashboard itself only sets preferences and shows the plan; the loxone controller drives
 the wallbox from that plan downstream.
 
-## Actuation (EV via the armed loxone controller)
+## Actuation (EV via the loxone controller)
 
-EV charging is actuated in production by the unified `loxone` controller (armed). The standalone
+EV charging is actuated by the unified `loxone` controller. The standalone
 `mpc-controller-ev` path below is superseded by it and ships **dry-run**:
 
 ```
@@ -169,5 +169,4 @@ plan /api/plan/latest ─▶ mpc-plan-publisher ─(MQTT mpc/control/ev)─▶ m
 Like every controller it is **dry-run by default** behind two gates — config `armed: true` **and**
 `MPC_CONTROLLER_ARM=i-understand-this-actuates` — and carries a `valid_until` deadman (`hold` →
 loxone resumes, or `all_off`). This standalone EV path stays dry-run — it is superseded by the unified
-`loxone` controller; the armed `growatt` + `loxone` controllers now drive the battery and heating in
-production.
+`loxone` controller; the `growatt` + `loxone` controllers drive the battery and heating.

--- a/docs/ev.md
+++ b/docs/ev.md
@@ -3,8 +3,9 @@
 An EV charger is modelled as a **controllable electrical flexible load** with a battery, a target SoC,
 and a deadline. The optimizer schedules the charge toward the target at lowest cost — co-optimised
 with the home battery, solar, heating, and HVAC in the one LP — but **only while the car is
-controllable on our own wallbox**. Everything is **shadow / read-only**: the plan is a recommendation;
-nothing is actuated until a controller is explicitly armed.
+controllable on our own wallbox**. The brain stays **read-only** (the plan is a recommendation); a
+controller actuates only when explicitly armed behind its two-key gate — the unified `loxone` controller
+is now armed in production and drives EV charging downstream.
 
 EV support activates only when at least one charger is configured — the dashboard's EV screen and the
 `/api/ev*` endpoints appear conditionally (via `/api/capabilities`).
@@ -146,11 +147,13 @@ Conditional on `has_ev`. Per charger it shows the status badge (on our wallbox /
 / driving), the car SoC → target, the first-block charge power, the planned session energy, and a
 **source-stacked** charge-schedule chart (solar / grid / battery → car per 15-min block). The
 **strategy / target / deadline** controls `POST` to the preference endpoint, and the next plan reflects
-them. Shadow only — nothing is actuated.
+them. The dashboard itself only sets preferences and shows the plan; the armed loxone controller drives
+the wallbox from that plan downstream.
 
-## Actuation (the EV controller — dry-run draft)
+## Actuation (EV via the armed loxone controller)
 
-The path to hardware mirrors the other [controllers](controllers.md) and ships **dry-run**:
+EV charging is actuated in production by the unified `loxone` controller (armed). The standalone
+`mpc-controller-ev` path below is superseded by it and ships **dry-run**:
 
 ```
 plan /api/plan/latest ─▶ mpc-plan-publisher ─(MQTT mpc/control/ev)─▶ mpc-controller-ev ─(UDP)─▶ Loxone wallbox
@@ -165,4 +168,6 @@ plan /api/plan/latest ─▶ mpc-plan-publisher ─(MQTT mpc/control/ev)─▶ m
 
 Like every controller it is **dry-run by default** behind two gates — config `armed: true` **and**
 `MPC_CONTROLLER_ARM=i-understand-this-actuates` — and carries a `valid_until` deadman (`hold` →
-loxone resumes, or `all_off`). Nothing is armed; the live house is driven by `loxone_smart_home`.
+loxone resumes, or `all_off`). This standalone EV path stays dry-run — it is superseded by the unified
+`loxone` controller; the armed `growatt` + `loxone` controllers now drive the battery and heating in
+production.

--- a/docs/loxone-controller-plan.md
+++ b/docs/loxone-controller-plan.md
@@ -1,6 +1,6 @@
 # Unified Loxone controller — plan
 
-> **Status: armed in production** (`armed: true` + the `MPC_CONTROLLER_ARM` env token; the two-key gate).
+> **Actuation is two-key** (`armed: true` + the `MPC_CONTROLLER_ARM` env token; the gate).
 > A single `controllers/loxone` crate that owns the UDP edge to the
 > Loxone Miniserver — **all** Loxone-bound actuation (heating, EV power, and whatever comes later) in
 > one place, exactly mirroring how `controllers/growatt` owns the inverter. It supersedes the separate
@@ -268,8 +268,8 @@ config row either way)*.
 
 ## 10. Migration & rollout (shadow-first, non-disruptive)
 
-> **Status: complete — armed in production.** The phases below are the (now-finished) shadow-first
-> rollout sequence; the controller is armed behind the two-key gate + the Loxone-side `MPCActive` watchdog.
+> **Status: complete.** The phases below are the (now-finished) shadow-first
+> rollout sequence; the controller actuates behind the two-key gate + the Loxone-side `MPCActive` watchdog.
 
 1. **Build** the protocol variant + `controllers/loxone` + the publisher `loxone` block. Dry-run by
    default; nothing actuates. CI stays green (the core MPC stays MQTT-free — controllers own MQTT).

--- a/docs/loxone-controller-plan.md
+++ b/docs/loxone-controller-plan.md
@@ -1,6 +1,6 @@
 # Unified Loxone controller — plan
 
-> **Status: implemented on this branch.** Ships dry-run / shadow only (`armed: false` by default).
+> **Status: armed in production** (`armed: true` + the `MPC_CONTROLLER_ARM` env token; the two-key gate).
 > A single `controllers/loxone` crate that owns the UDP edge to the
 > Loxone Miniserver — **all** Loxone-bound actuation (heating, EV power, and whatever comes later) in
 > one place, exactly mirroring how `controllers/growatt` owns the inverter. It supersedes the separate
@@ -258,7 +258,7 @@ config row either way)*.
 ## 9. Critical files
 
 - `controllers/protocol/src/lib.rs` — `Payload::Loxone`, `LoxoneWrite` (+ tests).
-- `controllers/loxone/` (new) — `Cargo.toml`, `src/{config.rs, translate.rs, main.rs}`, `loxone.example.json5`.
+- `controllers/loxone/` (new) — `Cargo.toml`, `src/{config.rs, translate.rs, main.rs}`, `loxone.json5`.
 - `controllers/publisher/src/{config.rs, build.rs}` — `LoxonePub` block + builder; deprecate `heating`/`ev`.
 - root `Cargo.toml` — add `controllers/loxone` to the workspace.
 - `docs/controllers.md` — document the unified controller, the `MPCActive` gate, the VI scheme.
@@ -267,6 +267,9 @@ config row either way)*.
 ---
 
 ## 10. Migration & rollout (shadow-first, non-disruptive)
+
+> **Status: complete — armed in production.** The phases below are the (now-finished) shadow-first
+> rollout sequence; the controller is armed behind the two-key gate + the Loxone-side `MPCActive` watchdog.
 
 1. **Build** the protocol variant + `controllers/loxone` + the publisher `loxone` block. Dry-run by
    default; nothing actuates. CI stays green (the core MPC stays MQTT-free — controllers own MQTT).

--- a/docs/mqtt-architecture.md
+++ b/docs/mqtt-architecture.md
@@ -1,6 +1,8 @@
 # MQTT architecture & the Loxone UDP→MQTT migration (design)
 
-> **Status: design proposal — no code yet.** This document defines (1) the target MQTT topic
+> **Status: partially implemented.** The `controllers/` actuation side (publisher → MQTT → the armed
+> growatt/loxone controllers) is built and armed in production; the broader Loxone UDP⇄MQTT gateway
+> migration below is still planned. This document defines (1) the target MQTT topic
 > structure for the whole house — Loxone read/write *and* MPC-brain read/write — and (2) the plan for
 > a self-hosted gateway repo that converts Loxone UDP ⇄ MQTT and persists everything to InfluxDB.
 > It is grounded in what the system actually reads and writes today (`loxone_smart_home` Python,
@@ -386,7 +388,7 @@ loxone_smart_home"*). Concretely:
   `controller_protocol` envelope conventions.
 - Reuse `adapters/mqtt-bridge`'s InfluxDB line-protocol writer + protected-bucket guard for the
   historian.
-- Same **deployment story** as the MPC shadow: static musl `cargo zigbuild`, a tiny alpine Docker
+- Same **deployment story** as the MPC brain: static musl `cargo zigbuild`, a tiny alpine Docker
   image, `--restart unless-stopped` on `caddy_net` (see `memory/mpchc-shadow-deployment.md`).
 
 *Alternative:* evolve the existing Python `loxone_smart_home` modules in place (fastest, but keeps the
@@ -468,8 +470,8 @@ old path keeps working). Gateway now parses Loxone UDP directly and publishes `l
 Switch the heating/EV controllers' south side from "send UDP" to "publish `loxone/cmd/…`". Gateway
 `udp-out` subscribes `loxone/cmd/#` and drives the Loxone virtual inputs — i.e. the same UDP packets
 Loxone already understands, now sourced from the controllers via MQTT. The Python `mqtt_bridge` is
-retired. **Still dry-run** until the controllers are armed (two-key) — actuation is a separate,
-deliberate step, gated by the production-safety rule.
+retired. The controllers are already **armed** (two-key gate); this phase reroutes that live actuation
+through the gateway rather than direct UDP — still a separate, deliberate step gated by production safety.
 
 **Phase 4 — (optional) Loxone-native MQTT.**
 If/when Loxone Gen2 MQTT is enabled, Loxone publishes `loxone/…` and subscribes `loxone/cmd/…`

--- a/docs/mqtt-architecture.md
+++ b/docs/mqtt-architecture.md
@@ -1,7 +1,7 @@
 # MQTT architecture & the Loxone UDP→MQTT migration (design)
 
-> **Status: partially implemented.** The `controllers/` actuation side (publisher → MQTT → the armed
-> growatt/loxone controllers) is built and armed in production; the broader Loxone UDP⇄MQTT gateway
+> **Status: partially implemented.** The `controllers/` actuation side (publisher → MQTT → the
+> growatt/loxone controllers) is built; the broader Loxone UDP⇄MQTT gateway
 > migration below is still planned. This document defines (1) the target MQTT topic
 > structure for the whole house — Loxone read/write *and* MPC-brain read/write — and (2) the plan for
 > a self-hosted gateway repo that converts Loxone UDP ⇄ MQTT and persists everything to InfluxDB.
@@ -470,7 +470,7 @@ old path keeps working). Gateway now parses Loxone UDP directly and publishes `l
 Switch the heating/EV controllers' south side from "send UDP" to "publish `loxone/cmd/…`". Gateway
 `udp-out` subscribes `loxone/cmd/#` and drives the Loxone virtual inputs — i.e. the same UDP packets
 Loxone already understands, now sourced from the controllers via MQTT. The Python `mqtt_bridge` is
-retired. The controllers are already **armed** (two-key gate); this phase reroutes that live actuation
+retired. The controllers already **actuate** (two-key gate); this phase reroutes that live actuation
 through the gateway rather than direct UDP — still a separate, deliberate step gated by production safety.
 
 **Phase 4 — (optional) Loxone-native MQTT.**

--- a/src/app.rs
+++ b/src/app.rs
@@ -387,7 +387,7 @@ pub struct TimelineBlock {
     /// **Predicted** air temperature (°C) per controlled zone at the end of the block.
     pub temp_c: HashMap<String, f64>,
     /// Recommended Growatt slot mode and the price-gated export / inverter levers — applied by the
-    /// armed Growatt controller for the live block.
+    /// Growatt controller for the live block.
     pub slot: String,
     pub export_enabled: bool,
     pub inverter_on: bool,
@@ -456,7 +456,7 @@ pub struct FirstStep {
     pub grid_import_kw: f64,
     pub grid_export_kw: f64,
     /// Recommended Growatt setup for the coming block — slot mode + the two toggles, applied by the
-    /// armed Growatt controller.
+    /// Growatt controller.
     pub mode: ModeStep,
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -168,7 +168,7 @@ fn tariff_prices(
 /// two **independent, price-gated toggles** — export enable/disable and the inverter on/off master
 /// switch — mirroring how the live controller is actually set up. It is a read-off of the recommended
 /// intent, not a literal echo of the controller's register; the brain itself never actuates — the
-/// **armed** Growatt controller applies it downstream (heating/EV stay shadow).
+/// **armed** controllers apply it downstream (Growatt the battery, loxone the heating/EV).
 #[derive(Debug, Clone, Serialize)]
 pub struct ModeStep {
     /// Battery action in `loxone_smart_home`'s vocabulary: `regular` / `charge_from_grid` /
@@ -311,7 +311,7 @@ pub struct PlanReport {
     /// entry here means the clear-sky model over those arrays stood in for the Solcast forecast.
     pub placeholder_inputs: Vec<String>,
     /// The controls the optimizer chose for the coming block — the battery plan drives the **armed**
-    /// Growatt controller; the heating decisions stay shadow (advisory, not actuated).
+    /// Growatt controller and the heating decisions the **armed** loxone controller (downstream).
     pub first_step: FirstStep,
     /// The full per-15-min-block plan as **timestamped rows** — prices, PV, SoC, battery, grid,
     /// heating and predicted temperature per controlled zone, plus the recommended Growatt mode.
@@ -324,7 +324,7 @@ pub struct PlanReport {
 }
 
 /// One EV charger's live fused state and the plan's charge schedule (per block) with its source
-/// breakdown — shadow only (a controller *would* drive the wallbox; nothing is actuated here).
+/// breakdown — the brain only reports it; the **armed** loxone controller drives the wallbox downstream.
 #[derive(Debug, Clone, Serialize)]
 pub struct EvChargerPlan {
     pub name: String,
@@ -393,7 +393,7 @@ pub struct TimelineBlock {
     pub inverter_on: bool,
 }
 
-/// The live internal-gain self-correction, published by the shadow loop after each re-fit so the
+/// The live internal-gain self-correction, published by the MPC loop after each re-fit so the
 /// `/api/calibration/gains` endpoint can report what the model is currently assuming and when it
 /// was learnt (see [`crate::validate::fit_internal_gains`]).
 #[derive(Debug, Clone, Serialize)]
@@ -424,7 +424,7 @@ pub struct ScheduledFit {
     pub source: String,
 }
 
-/// A plan with the instant it was computed — what the shadow loop publishes for the API.
+/// A plan with the instant it was computed — what the MPC loop publishes for the API.
 #[derive(Debug, Clone, Serialize)]
 pub struct TimestampedPlan {
     pub computed_at: DateTime<Utc>,
@@ -553,18 +553,18 @@ pub async fn zone_temp_history(
 pub struct PlanCache {
     pub consumption: ConsumptionModel,
     pub calibration: Calibration,
-    /// Per-zone internal gains (W) used by the plan. The shadow loop re-fits these from a trailing
+    /// Per-zone internal gains (W) used by the plan. The MPC loop re-fits these from a trailing
     /// window (see [`fit_live_internal_gains`]) on its own slow cadence and writes them here; absent
     /// that, [`build_cache`] seeds them from the calibrated `heating` config values.
     pub internal_gains: HashMap<String, f64>,
-    /// Fitted scheduled-load magnitudes (W, ≥ 0), aligned 1:1 to `config.scheduled_loads`. The shadow
+    /// Fitted scheduled-load magnitudes (W, ≥ 0), aligned 1:1 to `config.scheduled_loads`. The MPC
     /// loop writes its live re-fit here; [`build_cache`] seeds them to zero (no effect) until the
     /// first fit lands.
     pub scheduled_w: Vec<f64>,
 }
 
 /// Build the cacheable slow inputs — the 7-day PV-calibration backtest and the trailing-window
-/// consumption training (the two heaviest reads). Refreshed periodically by the shadow loop. The
+/// consumption training (the two heaviest reads). Refreshed periodically by the MPC loop. The
 /// internal gains start at the config baseline; the loop overwrites them with its live re-fit.
 pub async fn build_cache(db: &SourceClients, config: &ControlConfig) -> PlanCache {
     let offset = config.site.utc_offset_hours;
@@ -636,7 +636,7 @@ pub async fn fit_live_internal_gains(
     {
         Ok(fit) => Some(fit),
         Err(e) => {
-            eprintln!("[mpc shadow] internal-gain re-fit failed ({e}); keeping previous gains");
+            eprintln!("[mpc] internal-gain re-fit failed ({e}); keeping previous gains");
             None
         }
     }

--- a/src/dashboard/app.js
+++ b/src/dashboard/app.js
@@ -600,7 +600,7 @@ screens.system = {
       <section class="card"><div class="card-head"><div class="card-title"><span class="ico">📡</span> Data feed health</div></div><div id="sys-feeds"></div></section>
     </div>
     <section class="card span-full" style="margin-top:18px">
-      <div class="card-head"><div class="card-title"><span class="ico">🧾</span> Decision now (raw)</div><div class="card-sub">the raw per-controller decision (battery is armed; heating/EV shadow)</div></div>
+      <div class="card-head"><div class="card-title"><span class="ico">🧾</span> Decision now (raw)</div><div class="card-sub">the raw per-controller decision (battery, heating &amp; EV armed)</div></div>
       <div id="sys-decision"></div>
     </section>
     <section class="card span-full" style="margin-top:18px">
@@ -696,7 +696,7 @@ screens.ev = {
     <div id="ev-cards" class="grid cols-2"></div>
     <section class="card span-full" style="margin-top:18px">
       <div class="card-head"><div class="card-title"><span class="ico">🔌</span> Charge schedule — by source</div>
-        <div class="card-sub">solar / grid / battery → car, per 15-min block (shadow only)</div></div>
+        <div class="card-sub">solar / grid / battery → car, per 15-min block (armed)</div></div>
       <div class="chart tall" id="ev-chart"></div>
     </section>`;
   },
@@ -784,6 +784,6 @@ async function init() {
   go(location.hash.slice(2) || 'home');
   tickClock(); setInterval(tickClock, 1000);
   timer = setInterval(refresh, 10000); // poll every 10s
-  $('#footer').innerHTML = `MPC Home Control — read-only shadow monitor · data via the <a class="link" href="/api">JSON API</a>`;
+  $('#footer').innerHTML = `MPC Home Control — read-only dashboard · the armed controllers actuate the house · data via the <a class="link" href="/api">JSON API</a>`;
 }
 document.addEventListener('DOMContentLoaded', init);

--- a/src/dashboard/app.js
+++ b/src/dashboard/app.js
@@ -600,7 +600,7 @@ screens.system = {
       <section class="card"><div class="card-head"><div class="card-title"><span class="ico">📡</span> Data feed health</div></div><div id="sys-feeds"></div></section>
     </div>
     <section class="card span-full" style="margin-top:18px">
-      <div class="card-head"><div class="card-title"><span class="ico">🧾</span> Decision now (raw)</div><div class="card-sub">the raw per-controller decision (battery, heating &amp; EV armed)</div></div>
+      <div class="card-head"><div class="card-title"><span class="ico">🧾</span> Decision now (raw)</div><div class="card-sub">the raw per-controller decision (battery, heating &amp; EV)</div></div>
       <div id="sys-decision"></div>
     </section>
     <section class="card span-full" style="margin-top:18px">
@@ -696,7 +696,7 @@ screens.ev = {
     <div id="ev-cards" class="grid cols-2"></div>
     <section class="card span-full" style="margin-top:18px">
       <div class="card-head"><div class="card-title"><span class="ico">🔌</span> Charge schedule — by source</div>
-        <div class="card-sub">solar / grid / battery → car, per 15-min block (armed)</div></div>
+        <div class="card-sub">solar / grid / battery → car, per 15-min block</div></div>
       <div class="chart tall" id="ev-chart"></div>
     </section>`;
   },
@@ -784,6 +784,6 @@ async function init() {
   go(location.hash.slice(2) || 'home');
   tickClock(); setInterval(tickClock, 1000);
   timer = setInterval(refresh, 10000); // poll every 10s
-  $('#footer').innerHTML = `MPC Home Control — read-only dashboard · the armed controllers actuate the house · data via the <a class="link" href="/api">JSON API</a>`;
+  $('#footer').innerHTML = `MPC Home Control — read-only dashboard · the controllers actuate the house · data via the <a class="link" href="/api">JSON API</a>`;
 }
 document.addEventListener('DOMContentLoaded', init);

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -13,7 +13,7 @@
         <div class="brand">
             <span class="brand-logo">⚡</span>
             <span class="brand-name">MPC&nbsp;Home</span>
-            <span class="brand-tag">shadow</span>
+            <span class="brand-tag">armed</span>
         </div>
         <nav class="nav" id="nav"></nav>
         <div class="topbar-right">

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -13,7 +13,6 @@
         <div class="brand">
             <span class="brand-logo">⚡</span>
             <span class="brand-name">MPC&nbsp;Home</span>
-            <span class="brand-tag">armed</span>
         </div>
         <nav class="nav" id="nav"></nav>
         <div class="topbar-right">

--- a/src/dashboard/style.css
+++ b/src/dashboard/style.css
@@ -85,10 +85,6 @@ body {
 .brand { display: flex; align-items: center; gap: 9px; font-weight: 700; font-size: 1.05rem; }
 .brand-logo { font-size: 1.3rem; filter: drop-shadow(0 0 6px var(--amber)); }
 .brand-name { letter-spacing: 0.2px; }
-.brand-tag {
-    font-size: 0.62rem; font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
-    color: var(--amber); background: var(--amber-soft); padding: 2px 7px; border-radius: 999px;
-}
 
 .nav { display: flex; gap: 4px; margin-left: 8px; flex: 1; overflow-x: auto; scrollbar-width: none; }
 .nav::-webkit-scrollbar { display: none; }
@@ -180,7 +176,6 @@ body {
     .topbar { flex-wrap: wrap; row-gap: 10px; }
     .nav { order: 3; flex-basis: 100%; margin-left: 0; flex-wrap: wrap; overflow-x: visible; }
     .clock { display: none; }
-    .brand-tag { display: none; }
 }
 .flow-node {
     background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm);

--- a/src/forecast_validation.rs
+++ b/src/forecast_validation.rs
@@ -1,7 +1,7 @@
 //! Forward-prediction validation — "predict now, score against reality later".
 //!
 //! The plan carries a forward temperature prediction per zone ([`crate::app::TimestampedPlan`]).
-//! The shadow loop periodically **snapshots** that prediction to a small JSON file; this module
+//! The MPC loop periodically **snapshots** that prediction to a small JSON file; this module
 //! later scores the elapsed part of a snapshot against the measured zone temperatures, so the
 //! `/api/forecast/validation` endpoint can show how well the heat model actually predicted the day.
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ use state_space::StateSpace;
 use tools::sun::calculate_tilted_irradiance;
 
 /// Scratch entrypoint: load the model, build the network and state-space, and run each subsystem's
-/// demo — or, with the `serve` argument, start the read-only monitoring API and shadow MPC loop.
+/// demo — or, with the `serve` argument, start the read-only monitoring API and MPC loop.
 /// Not a finished control loop.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/src/mpc_loop.rs
+++ b/src/mpc_loop.rs
@@ -1,12 +1,13 @@
-//! The shadow rolling-horizon MPC loop.
+//! The rolling-horizon MPC loop.
 //!
 //! On a fixed schedule it re-plans the whole house from the **current measured state** (the
 //! receding horizon comes from re-planning with `start = now`; there is no model-state to carry
 //! forward — each tick re-estimates from measurements and reads the live battery SoC). It logs the
 //! decisions it *would* apply for the coming hour and publishes the latest plan for the web API.
 //!
-//! **Shadow only.** It never actuates and never writes InfluxDB — the live `loxone_smart_home`
-//! still operates the house. This is a confidence-building observer, not a controller.
+//! **Read-only loop.** It never actuates or writes InfluxDB itself — it only publishes the plan to the
+//! API. Downstream, the armed controllers (growatt battery, loxone heating/EV) consume that plan and
+//! drive the house; `loxone_smart_home` keeps the domains not yet cut over.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -36,7 +37,7 @@ pub async fn run(state: Arc<AppState>, tick: Duration) {
     let mut interval = tokio::time::interval(tick);
     let mut cache: Option<(Instant, PlanCache)> = None;
     // The heating relays decided at the current 15-min block's start, held for its 15 minutes so the
-    // relays don't flip mid-block under the per-minute re-planning (a min on/off time, shadow-side).
+    // relays don't flip mid-block under the per-minute re-planning (a minimum on/off time).
     let mut committed: Option<(DateTime<Utc>, HashMap<String, f64>)> = None;
 
     // Live internal-gain self-correction: re-fit from a trailing window on a slow cadence (the gains
@@ -187,7 +188,7 @@ pub async fn run(state: Arc<AppState>, tick: Duration) {
                         // Only advance the clock on a real write, so a transient failure retries.
                         Some(Ok(())) => last_snapshot = Some(Instant::now()),
                         Some(Err(e)) => {
-                            eprintln!("[mpc shadow] forecast snapshot write failed: {e}")
+                            eprintln!("[mpc] forecast snapshot write failed: {e}")
                         }
                         None => last_snapshot = Some(Instant::now()), // empty plan: nothing to snapshot
                     }
@@ -198,7 +199,7 @@ pub async fn run(state: Arc<AppState>, tick: Duration) {
                     plan,
                 });
             }
-            Err(e) => eprintln!("[mpc shadow] planning failed: {e}"),
+            Err(e) => eprintln!("[mpc] planning failed: {e}"),
         }
     }
 }
@@ -209,7 +210,7 @@ fn log_decision(plan: &PlanReport) {
     let heat_kw: f64 = fs.heat_kw.values().sum();
     let battery_kw = fs.battery_discharge_kw - fs.battery_charge_kw; // + = discharging
     println!(
-        "[mpc shadow] {}: mode {} (export {}, inverter {}), heat {heat_kw:.1} kW, battery {battery_kw:+.1} kW, grid import {:.1} / export {:.1} kW \
+        "[mpc] {}: mode {} (export {}, inverter {}), heat {heat_kw:.1} kW, battery {battery_kw:+.1} kW, grid import {:.1} / export {:.1} kW \
          (24 h cost {:.2} EUR / {:.0} CZK){}",
         fs.hour_start.format("%Y-%m-%d %H:%M UTC"),
         fs.mode.slot,
@@ -230,7 +231,7 @@ fn log_decision(plan: &PlanReport) {
 /// Log the freshly re-fitted per-zone internal gains (the live self-correction), strongest first.
 fn log_gains(gains: &HashMap<String, f64>) {
     if gains.is_empty() {
-        println!("[mpc shadow] internal-gain re-fit: no extra gain needed in any zone");
+        println!("[mpc] internal-gain re-fit: no extra gain needed in any zone");
         return;
     }
     let mut items: Vec<(&String, &f64)> = gains.iter().collect();
@@ -241,7 +242,7 @@ fn log_gains(gains: &HashMap<String, f64>) {
         .collect::<Vec<_>>()
         .join(", ");
     println!(
-        "[mpc shadow] internal-gain re-fit: {list} (total {:.0} W)",
+        "[mpc] internal-gain re-fit: {list} (total {:.0} W)",
         gains.values().sum::<f64>(),
     );
 }

--- a/src/mpc_loop.rs
+++ b/src/mpc_loop.rs
@@ -6,7 +6,7 @@
 //! decisions it *would* apply for the coming hour and publishes the latest plan for the web API.
 //!
 //! **Read-only loop.** It never actuates or writes InfluxDB itself — it only publishes the plan to the
-//! API. Downstream, the armed controllers (growatt battery, loxone heating/EV) consume that plan and
+//! API. Downstream, the controllers (growatt battery, loxone heating/EV) consume that plan and
 //! drive the house; `loxone_smart_home` keeps the domains not yet cut over.
 
 use std::collections::HashMap;

--- a/src/optimize/config.rs
+++ b/src/optimize/config.rs
@@ -51,21 +51,21 @@ pub struct ControlConfig {
     /// How far back to train the consumption model from measured history (days).
     #[serde(default = "default_consumption_history_days")]
     pub consumption_history_days: i64,
-    /// How often the shadow MPC loop re-plans (minutes).
+    /// How often the MPC loop re-plans (minutes).
     #[serde(default = "default_mpc_tick_minutes")]
     pub mpc_tick_minutes: u64,
-    /// Trailing window (days) the shadow loop re-fits the per-zone internal gains over, so the live
+    /// Trailing window (days) the MPC loop re-fits the per-zone internal gains over, so the live
     /// forecast tracks changes in occupant behaviour. A few days smooths sensor noise yet adapts
     /// within a week; the fit falls back to the `heating` config gains when there's not enough data.
     /// Clamped to a minimum of 3 days at use.
     #[serde(default = "default_internal_gain_window_days")]
     pub internal_gain_window_days: i64,
-    /// How often (hours) the shadow loop re-fits the internal gains. They drift slowly (behavioural),
+    /// How often (hours) the MPC loop re-fits the internal gains. They drift slowly (behavioural),
     /// so this is far longer than the plan tick — keeping the self-correction's overhead negligible.
     /// 0 disables the live re-fit, pinning the gains to the `heating` config values.
     #[serde(default = "default_internal_gain_recalibrate_hours")]
     pub internal_gain_recalibrate_hours: u64,
-    /// How often (minutes) the shadow loop snapshots its forward temperature prediction for the
+    /// How often (minutes) the MPC loop snapshots its forward temperature prediction for the
     /// `/api/forecast/validation` scorecard (predict now, score against measured later). 0 disables
     /// snapshotting. Stored to a JSON file (`MPC_FORECAST_STORE`, default `forecast_snapshots.json`).
     #[serde(default = "default_forecast_snapshot_minutes")]
@@ -368,7 +368,7 @@ fn default_ground_temperature_c() -> f64 {
 ///
 /// The OTE day-ahead price is in EUR/MWh; every fee here is in **CZK/kWh** (the form the Czech
 /// distribution tariff is quoted in), converted with [`Self::eur_czk_rate`]. Mirrors the
-/// `loxone_smart_home` Growatt settings so the shadow plan sees the same economics as the live
+/// `loxone_smart_home` Growatt settings so the MPC plan sees the same economics as the live
 /// controller. Import pays distribution + system services (two-tariff VT/NT by local hour); export
 /// (FVE buyback) is the spot minus a fixed sell fee, with no distribution.
 #[derive(Debug, Clone, Deserialize)]
@@ -390,7 +390,7 @@ pub struct TariffConfig {
     /// Battery wear cost charged once per kWh discharged (CZK/kWh).
     pub battery_amortisation_czk: f64,
     /// Power the inverter off when the spot price is below this (CZK/kWh): the deeply-negative
-    /// hours where exporting would cost money. Drives the shadow inverter-off recommendation.
+    /// hours where exporting would cost money. Drives the MPC inverter-off recommendation.
     pub inverter_off_price_czk: f64,
 }
 

--- a/src/optimize/config.rs
+++ b/src/optimize/config.rs
@@ -1205,6 +1205,21 @@ mod tests {
         assert_eq!(src.unit_profile(7, 12 * 60), 1.0);
     }
 
+    /// The live `config.json5` must load + validate, with the technical_room water heat-pump's
+    /// summer room-source `scheduled_loads` entry present — a regression guard against an edit (or a
+    /// deploy from a diverged copy) silently dropping it, as the server/repo configs did once.
+    #[test]
+    fn real_config_loads_with_scheduled_loads() {
+        let cfg = ControlConfig::load("config.json5").expect("config.json5 loads + validates");
+        let hp = cfg
+            .scheduled_loads
+            .iter()
+            .find(|l| l.zone == "technical_room")
+            .expect("technical_room water heat-pump scheduled load present");
+        assert_eq!(hp.kind, LoadKind::Sink);
+        assert_eq!(hp.power_w, Some(1600.0));
+    }
+
     #[test]
     fn validate_scheduled_loads_rejects_malformed() {
         let ok = ControlConfig::from_json5(

--- a/src/pv_backtest.rs
+++ b/src/pv_backtest.rs
@@ -164,8 +164,13 @@ pub async fn backtest_pv(
     // end-of-day remnant — see `SnapshotPick`). Look back a couple of days further than the actuals
     // window: a day's full-day forecast is often snapshotted the evening before it begins.
     let fc_start = format!("-{}d", days + 2);
-    let forecasts =
-        forecast_curves(db, "solar_forecast_history", &fc_start, SnapshotPick::Fullest).await?;
+    let forecasts = forecast_curves(
+        db,
+        "solar_forecast_history",
+        &fc_start,
+        SnapshotPick::Fullest,
+    )
+    .await?;
     ensure!(
         !forecasts.is_empty(),
         "no solar forecast history in the window"

--- a/src/pv_backtest.rs
+++ b/src/pv_backtest.rs
@@ -23,7 +23,7 @@ use chrono::{DateTime, FixedOffset, NaiveDate, Timelike, Utc};
 use serde::Serialize;
 
 use crate::influxdb::TimeSample;
-use crate::solar_forecast::forecast_curves;
+use crate::solar_forecast::{forecast_curves, SnapshotPick};
 use crate::source::SourceClients;
 use crate::tools::{mean, rmse};
 
@@ -60,6 +60,10 @@ pub struct PvBacktest {
     pub total_actual_kwh: f64,
     pub scored_hours: usize,
     pub curtailed_hours: usize,
+    /// Days excluded from scoring because the stored forecast was too incomplete to compare fairly
+    /// (a forecast-snapshotting gap left only an end-of-day remnant, or nothing). Surfaced so a data
+    /// gap reads as a gap rather than silently dragging the calibration — never as a forecast error.
+    pub incomplete_forecast_days: Vec<NaiveDate>,
 }
 
 /// Accumulator for one day's scored hours.
@@ -68,6 +72,10 @@ struct DayScore {
     solcast_kwh: f64,
     actual_kwh: f64,
     clean_hours: usize,
+    /// Scored hours where the forecast itself predicted daylight (≥ [`DAYLIGHT_KW`]). Far below
+    /// `clean_hours` means the stored curve was a truncated remnant (a snapshotting gap), not a
+    /// genuine zero forecast — used to drop the day from the calibration.
+    forecast_hours: usize,
     curtailed_hours: usize,
     sse: f64,
     bias_sum: f64,
@@ -96,6 +104,9 @@ fn score_day(
             continue;
         }
         s.clean_hours += 1;
+        if forecast >= DAYLIGHT_KW {
+            s.forecast_hours += 1;
+        }
         s.solcast_kwh += forecast;
         s.actual_kwh += measured;
         s.sse += (measured - forecast).powi(2);
@@ -149,7 +160,12 @@ pub async fn backtest_pv(
     // `export_enabled` / `battery_soc`); a different inverter remaps them without code.
     let export = db.curtailment_export_series(&start, "now()", "1h").await?;
     let soc = db.curtailment_soc_series(&start, "now()", "1h").await?;
-    let forecasts = forecast_curves(db, "solar_forecast_history", &start).await?;
+    // Score against the FULLEST snapshot per day, not the latest (which for a finished day is only the
+    // end-of-day remnant — see `SnapshotPick`). Look back a couple of days further than the actuals
+    // window: a day's full-day forecast is often snapshotted the evening before it begins.
+    let fc_start = format!("-{}d", days + 2);
+    let forecasts =
+        forecast_curves(db, "solar_forecast_history", &fc_start, SnapshotPick::Fullest).await?;
     ensure!(
         !forecasts.is_empty(),
         "no solar forecast history in the window"
@@ -171,6 +187,7 @@ pub async fn backtest_pv(
     dates.sort();
 
     let mut days_out = Vec::new();
+    let mut incomplete: Vec<NaiveDate> = Vec::new();
     let (mut tot_sse, mut tot_n, mut tot_sol, mut tot_act, mut tot_curt) =
         (0.0, 0usize, 0.0, 0.0, 0);
     for date in dates {
@@ -196,6 +213,14 @@ pub async fn backtest_pv(
         if score.clean_hours == 0 {
             continue;
         }
+        // Skip days whose stored forecast covers under half the generating daylight hours: a
+        // snapshotting gap left only an end-of-day remnant (or nothing), so the forecast reads
+        // near-zero. Scoring it would crater the Solcast total and spuriously inflate the PV
+        // calibration — exclude it and surface it as a data gap instead of a forecast error.
+        if score.forecast_hours * 2 < score.clean_hours {
+            incomplete.push(date);
+            continue;
+        }
         tot_sse += score.sse;
         tot_n += score.clean_hours;
         tot_sol += score.solcast_kwh;
@@ -219,6 +244,7 @@ pub async fn backtest_pv(
         total_actual_kwh: tot_act,
         scored_hours: tot_n,
         curtailed_hours: tot_curt,
+        incomplete_forecast_days: incomplete,
     })
 }
 
@@ -238,6 +264,18 @@ mod tests {
         assert!((s.actual_kwh - 3.5).abs() < 1e-12); // 1.5 + 2
         assert!((s.sse - 0.25).abs() < 1e-12); // 0.5^2 + 0^2
         assert!((s.bias_sum - 0.5).abs() < 1e-12); // +0.5 + 0
+    }
+
+    #[test]
+    fn score_day_counts_forecast_coverage() {
+        // The data-gap pattern: an end-of-day remnant forecast (only hour 19) vs a full afternoon of
+        // actual generation. `forecast_hours` must register the gap so the backtest can drop the day.
+        let solcast = HashMap::from([(19, 1.5)]);
+        let actual = HashMap::from([(10, 4.0), (11, 5.0), (12, 6.0), (19, 1.0)]);
+        let s = score_day(&solcast, &actual, &HashSet::new());
+        assert_eq!(s.clean_hours, 4); // four daylight hours have actual generation
+        assert_eq!(s.forecast_hours, 1); // the forecast predicted daylight in only one of them
+        assert!(s.forecast_hours * 2 < s.clean_hours); // the completeness guard would skip this day
     }
 
     #[test]

--- a/src/solar_forecast.rs
+++ b/src/solar_forecast.rs
@@ -124,7 +124,10 @@ pub(crate) async fn forecast_curves(
             has_solcast: source.contains("solcast"),
             sum: curve.values().sum(),
         };
-        if best.get(&d).is_none_or(|(b, _, _)| supersedes(pick, &cand, b)) {
+        if best
+            .get(&d)
+            .is_none_or(|(b, _, _)| supersedes(pick, &cand, b))
+        {
             best.insert(d, (cand, curve, source));
         }
     }

--- a/src/solar_forecast.rs
+++ b/src/solar_forecast.rs
@@ -1,13 +1,16 @@
 //! Read the house's PV forecast curve from InfluxDB.
 //!
 //! loxone stores its solar forecast in the `solar` bucket as an hourly kW curve (`hourly_json`,
-//! keyed by local hour-of-day) per `forecast_date`, re-snapshotted through the day. Solcast
-//! (≤9 free fetches/day) appears only in some snapshots — the day's final refresh is often a
-//! `model+api` fallback — so to use the best forecast we pick the latest snapshot whose `source`
-//! includes `solcast`, falling back to the latest snapshot overall. The hourly curve lives only in
-//! `solar_forecast_history` (the current `solar_forecast` measurement keeps just daily summaries),
-//! whose snapshots cover today and the next days — so both the backtest and the live MPC's `pv_kw`
-//! read it, the latter just taking each forecast_date's latest snapshot.
+//! keyed by local hour-of-day) per `forecast_date`, re-snapshotted through the day. Each snapshot
+//! only covers the hours **from its record time forward**, so a midday snapshot holds just the
+//! afternoon and the *latest* snapshot of a finished day is a near-empty end-of-day remnant.
+//! Solcast (≤9 free fetches/day) appears only in some snapshots — the day's final refresh is often
+//! a `model+api` fallback. The hourly curve lives only in `solar_forecast_history` (the current
+//! `solar_forecast` measurement keeps just daily summaries), whose snapshots cover today and the
+//! next days. Both the live MPC's `pv_kw` and the backtest read it, but pick differently (see
+//! [`SnapshotPick`]): the live path takes each date's *latest* snapshot (the remaining-day forecast
+//! it should plan against), while the backtest takes the *fullest* (full-day) snapshot so a finished
+//! day is scored against the forecast made while the whole day was still ahead — not the remnant.
 
 use std::collections::{HashMap, HashSet};
 
@@ -52,13 +55,47 @@ async fn raw_field_rows(
         .collect()
 }
 
-/// The best forecast curve per day from `measurement`, as a local-hour → kW map plus its `source`.
-/// Prefers the latest Solcast-tagged snapshot per `forecast_date`, falling back to the latest
-/// snapshot overall. `measurement` is `solar_forecast_history` (past) or `solar_forecast` (current).
+/// Which snapshot to use when a `forecast_date` has several (see the module docs: each curve covers
+/// only the hours from its record time forward).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SnapshotPick {
+    /// The latest (Solcast-preferred) snapshot — the forecast for the hours still ahead. This is what
+    /// the live planner wants: at noon it should plan only the remaining afternoon.
+    Latest,
+    /// The most complete (max-energy, Solcast-preferred) snapshot — the full-day forecast made while
+    /// the whole day was still ahead. This is what *scoring a finished day* needs; using the latest
+    /// remnant instead makes the forecast read near-zero and craters the PV calibration.
+    Fullest,
+}
+
+/// Comparison key for [`SnapshotPick`] selection (the curve/source ride along separately). `sum` is
+/// the curve's total energy — a proxy for completeness, since a truncated remnant sums far lower.
+struct SnapKey {
+    when: DateTime<Utc>,
+    has_solcast: bool,
+    sum: f64,
+}
+
+/// Whether `cand` should replace the current `best` snapshot under `pick`. The 1 kWh tolerance on
+/// "equally full" keeps a marginally-larger non-Solcast curve from displacing a Solcast one.
+fn supersedes(pick: SnapshotPick, cand: &SnapKey, best: &SnapKey) -> bool {
+    let solcast_or_fresher = (cand.has_solcast && !best.has_solcast)
+        || (cand.has_solcast == best.has_solcast && cand.when > best.when);
+    match pick {
+        SnapshotPick::Latest => solcast_or_fresher,
+        SnapshotPick::Fullest => {
+            cand.sum > best.sum + 1.0 || ((cand.sum - best.sum).abs() <= 1.0 && solcast_or_fresher)
+        }
+    }
+}
+
+/// The chosen forecast curve per day from `measurement`, as a local-hour → kW map plus its `source`,
+/// selected per [`SnapshotPick`]. `measurement` is `solar_forecast_history` (past) or `solar_forecast`.
 pub(crate) async fn forecast_curves(
     db: &SourceClients,
     measurement: &str,
     start: &str,
+    pick: SnapshotPick,
 ) -> Result<HashMap<NaiveDate, (HashMap<u32, f64>, String)>> {
     let sources: HashMap<(String, String), String> =
         raw_field_rows(db, measurement, "source", start)
@@ -67,37 +104,35 @@ pub(crate) async fn forecast_curves(
             .map(|(d, t, v)| ((d, t), v))
             .collect();
 
-    // Per date, prefer the latest Solcast snapshot (more accurate), else the latest of any source.
-    let mut best: HashMap<String, (DateTime<Utc>, bool, String, String)> = HashMap::new();
+    let mut best: HashMap<NaiveDate, (SnapKey, HashMap<u32, f64>, String)> = HashMap::new();
     for (date, time, json) in raw_field_rows(db, measurement, "hourly_json", start).await {
-        let Ok(when) = DateTime::parse_from_rfc3339(&time) else {
+        let (Ok(d), Ok(when)) = (
+            NaiveDate::parse_from_str(&date, "%Y-%m-%d"),
+            DateTime::parse_from_rfc3339(&time),
+        ) else {
             continue;
         };
-        let when = when.with_timezone(&Utc);
+        let Ok(curve) = parse_hourly_json(&json) else {
+            continue;
+        };
         let source = sources
             .get(&(date.clone(), time))
             .cloned()
             .unwrap_or_default();
-        let has_solcast = source.contains("solcast");
-        let better = match best.get(&date) {
-            Some((t, sol, _, _)) => (has_solcast && !sol) || (has_solcast == *sol && when > *t),
-            None => true,
+        let cand = SnapKey {
+            when: when.with_timezone(&Utc),
+            has_solcast: source.contains("solcast"),
+            sum: curve.values().sum(),
         };
-        if better {
-            best.insert(date, (when, has_solcast, json, source));
+        if best.get(&d).is_none_or(|(b, _, _)| supersedes(pick, &cand, b)) {
+            best.insert(d, (cand, curve, source));
         }
     }
 
-    let mut out = HashMap::new();
-    for (date, (_t, _sol, json, source)) in best {
-        if let (Ok(d), Ok(curve)) = (
-            NaiveDate::parse_from_str(&date, "%Y-%m-%d"),
-            parse_hourly_json(&json),
-        ) {
-            out.insert(d, (curve, source));
-        }
-    }
-    Ok(out)
+    Ok(best
+        .into_iter()
+        .map(|(d, (_k, curve, source))| (d, (curve, source)))
+        .collect())
 }
 
 /// The house PV forecast as hourly kW for the `horizon` hours from `start`. Hours with no forecast
@@ -116,7 +151,7 @@ pub async fn pv_forecast_kw(
     let offset = FixedOffset::east_opt(utc_offset_hours * 3600).context("invalid UTC offset")?;
     // The `-2d` look-back still finds the latest snapshot for every horizon date if re-snapshotting
     // paused (Solcast budget spent, an outage).
-    let curves = forecast_curves(db, "solar_forecast_history", "-2d").await?;
+    let curves = forecast_curves(db, "solar_forecast_history", "-2d", SnapshotPick::Latest).await?;
     let mut pv_kw = Vec::with_capacity(horizon);
     let mut missing = HashSet::new();
     for h in 0..horizon {
@@ -141,6 +176,47 @@ pub async fn pv_forecast_kw(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn at(rfc3339: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(rfc3339)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn snapshot_pick_latest_vs_fullest() {
+        // A finished day's full-day forecast (made the evening before) vs the end-of-day remnant.
+        let full = SnapKey {
+            when: at("2026-06-28T16:00:00Z"),
+            has_solcast: true,
+            sum: 76.0,
+        };
+        let remnant = SnapKey {
+            when: at("2026-06-28T17:30:00Z"),
+            has_solcast: true,
+            sum: 2.0,
+        };
+        // Latest: the later (remnant) snapshot wins regardless of energy — correct for live planning.
+        assert!(supersedes(SnapshotPick::Latest, &remnant, &full));
+        // Fullest: the higher-energy full-day snapshot wins even though it is older — correct scoring.
+        assert!(supersedes(SnapshotPick::Fullest, &full, &remnant));
+        assert!(!supersedes(SnapshotPick::Fullest, &remnant, &full));
+    }
+
+    #[test]
+    fn snapshot_pick_fullest_prefers_solcast_when_equally_full() {
+        let solcast = SnapKey {
+            when: at("2026-06-28T16:00:00Z"),
+            has_solcast: true,
+            sum: 76.0,
+        };
+        let model = SnapKey {
+            when: at("2026-06-28T17:00:00Z"),
+            has_solcast: false,
+            sum: 76.3,
+        }; // fresher + marginally larger, but not Solcast
+        assert!(!supersedes(SnapshotPick::Fullest, &model, &solcast));
+    }
 
     #[test]
     fn parse_hourly_json_handles_ints_and_floats() {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -539,7 +539,7 @@ fn fit_gains(
 
 /// Fit the per-zone internal gains (W) and scheduled-load magnitudes over a trailing window — the
 /// **live self-correction**. Same coupled fit as [`calibrate_internal_gains`] but returning only the
-/// fit, so the shadow loop can re-fit periodically and track changes in occupant behaviour (more/fewer
+/// fit, so the MPC loop can re-fit periodically and track changes in occupant behaviour (more/fewer
 /// people, appliance use) without any config or model edit. An empty result means the model needs no
 /// extra gain anywhere.
 #[allow(clippy::too_many_arguments)] // the model, heating, loads, site, window and time bounds are all distinct

--- a/src/web.rs
+++ b/src/web.rs
@@ -2,7 +2,7 @@
 //!
 //! Exposes the running brain over JSON: liveness/readiness, version, the estimated thermal state,
 //! the live dispatch plan (aggregates + a chart-ready per-block timeline), the PV / thermal
-//! model-accuracy backtests, the internal-gain self-correction, a shadow-vs-loxone comparison, and
+//! model-accuracy backtests, the internal-gain self-correction, a MPC-vs-loxone comparison, and
 //! the forward-prediction validation scorecard. The network and state-space are plain `Send + Sync`
 //! data, so they are shared across the multi-threaded server without copies. Strictly read-only —
 //! it never writes InfluxDB (only its own forecast-snapshot file) and never actuates.
@@ -54,7 +54,7 @@ pub struct AppState {
     pub longitude: Angle,
     /// When the process started (for uptime reporting).
     pub started_at: DateTime<Utc>,
-    /// The latest plan published by the shadow MPC loop (`None` until the first tick completes).
+    /// The latest plan published by the MPC loop (`None` until the first tick completes).
     pub latest: Mutex<Option<TimestampedPlan>>,
     /// The latest internal-gain re-fit published by the loop (`None` until the first fit lands).
     pub gains: Mutex<Option<GainsSnapshot>>,
@@ -200,7 +200,7 @@ async fn livez(State(s): State<Shared>) -> Json<Value> {
     }))
 }
 
-/// Readiness: the shadow loop has published a recent plan (so the DB is reachable and planning
+/// Readiness: the MPC loop has published a recent plan (so the DB is reachable and planning
 /// works). 503 if no plan yet or the last tick is too old.
 async fn readyz(State(s): State<Shared>) -> (StatusCode, Json<Value>) {
     let last = lock(&s.latest).clone();
@@ -271,7 +271,7 @@ async fn api_index() -> Json<Value> {
         { "path": "/api/state", "desc": "current per-zone air temperature (measured, model-anchored)" },
         { "path": "/api/zones/series?hours=N", "desc": "measured per-zone temperature series (comfort sparklines)" },
         { "path": "/api/plan", "desc": "on-demand whole-house plan (aggregates + timeline)" },
-        { "path": "/api/plan/latest", "desc": "latest plan published by the shadow loop (no recompute)" },
+        { "path": "/api/plan/latest", "desc": "latest plan published by the MPC loop (no recompute)" },
         { "path": "/api/plan/timeline", "desc": "the latest plan's per-block rows (chart-ready)" },
         { "path": "/api/history?hours=N", "desc": "measured PV (kW) + battery SoC (kWh) over today so far" },
         { "path": "/api/pv/backtest?days=N", "desc": "PV forecast vs actual" },
@@ -353,7 +353,7 @@ fn require_charger(s: &Shared, name: &str) -> Result<(), ApiError> {
     }
 }
 
-/// The latest plan published by the shadow MPC loop (no recompute). 503 until the first tick.
+/// The latest plan published by the MPC loop (no recompute). 503 until the first tick.
 async fn get_plan_latest(State(s): State<Shared>) -> Result<Json<Value>, ApiError> {
     latest_plan(&s, |p| serde_json::to_value(p))
 }
@@ -674,7 +674,7 @@ pub fn router(state: Shared) -> Router {
 }
 
 /// Serve the monitoring API on `127.0.0.1:port` (set `MPC_BIND=0.0.0.0` to expose from a container),
-/// with the shadow MPC loop running in the background (re-planning every `tick` and publishing to
+/// with the MPC loop running in the background (re-planning every `tick` and publishing to
 /// `/api/plan/latest`), until terminated.
 pub async fn serve(state: AppState, port: u16, tick: Duration) -> Result<()> {
     let shared: Shared = Arc::new(state);
@@ -684,7 +684,7 @@ pub async fn serve(state: AppState, port: u16, tick: Duration) -> Result<()> {
     let addr = format!("{bind_host}:{port}");
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     println!(
-        "Dashboard + monitoring API on http://{addr}/  (GET /api for the endpoint index); shadow MPC loop every {} min",
+        "Dashboard + monitoring API on http://{addr}/  (GET /api for the endpoint index); MPC loop every {} min",
         tick.as_secs() / 60
     );
     axum::serve(listener, app).await?;


### PR DESCRIPTION
Four related changes on the way to the controllers actuating the house:

1. **Arm the production controllers** — flip the config half of the two-key gate (`armed: true`) for growatt, loxone, and publisher; add `deploy/run-loxone.sh`; healthcheck now monitors mpc-loxone. Actuation still requires the `MPC_CONTROLLER_ARM` env token (the second key).
2. **Reconcile `config.json5` scheduled_loads** — bring the technical_room summer water-heat-pump sink (live on the server) into the repo as the source of truth; add a regression test.
3. **Fix the PV calibration** — the backtest scored Solcast against end-of-day remnant snapshots, inflating the live forecast ~1.9x. Score against the full-day snapshot and exclude data-gap days. Verified against live data: calibration 1.887 -> 0.979.
4. **Drop redundant 'armed' status labels** from the UI/docs (the two-key-gate mechanism stays).

Gates green locally: fmt, clippy (workspace, all targets), 208 tests, the cargo-tree MQTT-free check. Reviewed via multi-agent safety + docs passes.