### PR TITLE
House thermal-envelope dashboard screen + /api/model/{topology,solar}

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,7 @@ The MPC brain (`cargo run -- serve`) exposes a **read-only** JSON API on `:3000`
 forecast-snapshot file) and never actuates (the controllers actuate separately).
 
 `GET /` serves the **dashboard** — a self-contained multi-screen web app (Home + Energy, Heating,
-Model, System), embedded in the binary (ECharts vendored, works offline), driven entirely
+House, Model, System), embedded in the binary (ECharts vendored, works offline), driven entirely
 by the endpoints below. `GET /api` returns a machine-readable index of every endpoint.
 
 ## Response envelope
@@ -37,6 +37,11 @@ it in the envelope above.
 | `GET /readyz` | Readiness — `200` iff the loop published a plan recently, else `503` (`{ready, plan_available, last_tick_age_seconds, max_tick_age_seconds}`). |
 | `GET /health` | Topology + liveness (`git_sha`, `uptime_seconds`, `thermal_states`, `heated_zones`). |
 | `GET /api/version` | `{git_sha, built_at, config_fingerprint, model_fingerprint}` — what's deployed. |
+
+### Model & envelope
+
+- **`GET /api/model/topology`** — the building's **thermal envelope**, static (built from the model at startup, served with no DB): `{ zones: [{ name, volume_m3 (null for the outside/ground reservoirs), role: interior|outside|ground }], boundaries: [{ id, zone_a, zone_b, area_m2, azimuth_deg, tilt_deg, kind: interior|exterior|roof|ground, type_name, u_value (W/m²K), r_value (m²K/W), ua (W/K), solar_absorptance, layers: [{ material, thickness_mm, conductivity (W/mK), marker }] | null, initial_marker }], ground_temperature_c }`. Drives the **House** screen. `u_value` is the conventional ISO 6946 value (interior/exterior surface films included); `layers` are in the model's `zones[0]`→`zones[1]` order (exterior-first for walls, room-first for floors/roofs — the dashboard orients them for display).
+- **`GET /api/model/solar`** — live per-surface **clear-sky solar gain** at request time: `{ sun: { azimuth_deg, elevation_deg, up }, boundaries: [{ id, irradiance_wm2, solar_w }] }`. Only opaque (`Layered`) surfaces facing `outside` are included (matching the RC network's solar rule); `solar_w = irradiance × absorptance × area`. Cloud is **not** applied (clear-sky), so it reads the orientation effect — which faces are catching sun.
 
 ### Live & state
 

--- a/src/dashboard/app.js
+++ b/src/dashboard/app.js
@@ -235,6 +235,7 @@ const ROUTES = [
   { id: 'energy',  name: 'Energy',   ep: ['/api/plan/latest', '/api/live', '/api/history'] },
   { id: 'ev',      name: 'EV',       ep: ['/api/ev', '/api/plan/timeline'], cap: 'has_ev' },
   { id: 'heating', name: 'Heating',  ep: ['/api/plan/latest', '/api/state', '/api/zones'] },
+  { id: 'house',   name: 'House',    ep: ['/api/model/topology', '/api/model/solar', '/api/state', '/api/zones', '/api/live'] },
   { id: 'model',   name: 'Model',    ep: ['/api/calibration/gains', '/api/forecast/validation'] },
   { id: 'system',  name: 'System',   ep: ['/api/version', '/api/plan/latest'] },
 ];
@@ -725,6 +726,330 @@ screens.ev = {
       yAxis: [yAxis('kW')],
       series: [leg('solar_kw', css('--amber'), 'Solar'), leg('grid_kw', css('--blue'), 'Grid'), leg('batt_kw', css('--purple'), 'Battery')],
     }), true);
+  },
+};
+
+// ---- HOUSE (thermal envelope) ----
+// Static topology + the current selection/sort, kept across the 10s re-render so the graph isn't
+// rebuilt and the inspected boundary survives a refresh.
+const house = { topo: null, temps: {}, outside: null, ground: null, solar: {}, sun: null, comfort: {}, sel: null, sort: { key: 'ua', dir: -1 }, tableBuilt: false };
+
+// Colour a zone by live air temperature (cold blue → warm red).
+function tempColor(t) {
+  if (t == null || !isFinite(t)) return css('--faint');
+  const f = clamp((t - 16) / 10, 0, 1);
+  const stops = [[59, 130, 246], [52, 211, 153], [251, 191, 36], [244, 99, 99]];
+  const seg = f * (stops.length - 1), i = Math.min(Math.floor(seg), stops.length - 2), k = seg - i;
+  const c = stops[i].map((a, j) => Math.round(a + (stops[i + 1][j] - a) * k));
+  return `rgb(${c[0]},${c[1]},${c[2]})`;
+}
+const KIND = {
+  exterior: { color: '#f59e0b', label: 'Exterior wall', dash: false },
+  roof:     { color: '#60a5fa', label: 'Roof',          dash: true },
+  ground:   { color: '#b07d3b', label: 'Ground / floor', dash: true },
+  interior: { color: '#5b6b86', label: 'Interior',       dash: false },
+};
+const kindOf = (k) => KIND[k] || KIND.interior;
+const COMPASS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+const compassDir = (deg) => deg == null ? null : COMPASS[Math.round(((deg % 360) + 360) % 360 / 45) % 8];
+const nice = (s) => esc(String(s).replace(/_/g, ' '));
+// Layer fill by conductivity λ: insulation (low λ) bright, dense masonry (high λ) dark.
+function layerColor(lambda) {
+  const f = clamp(Math.log10(clamp(lambda, 0.02, 3) / 0.02) / Math.log10(150), 0, 1);
+  const l = Math.round(70 - 42 * f); // lightness 70%→28%
+  return `hsl(${Math.round(28 + 10 * (1 - f))} 45% ${l}%)`;
+}
+// Colour by insulation quality (U-value): well-insulated green → leaky red.
+function uColor(u) {
+  if (u == null || !isFinite(u)) return css('--faint');
+  const f = clamp((u - 0.15) / (1.35), 0, 1); // 0.15 (passive-house) → 1.5 (poor); opens clamp to red
+  const stops = [[52, 211, 153], [251, 191, 36], [244, 99, 99]]; // green → amber → red
+  const seg = f * 2, i = Math.min(Math.floor(seg), 1), k = seg - i;
+  const c = stops[i].map((a, j) => Math.round(a + (stops[i + 1][j] - a) * k));
+  return `rgb(${c[0]},${c[1]},${c[2]})`;
+}
+const heatGrade = (u) => u == null ? '—' : u < 0.25 ? 'A' : u < 0.4 ? 'B' : u < 0.7 ? 'C' : u < 1.1 ? 'D' : 'E';
+
+screens.house = {
+  mount() {
+    // Fresh DOM + disposed charts on every navigation — rebuild the table, keep no stale selection.
+    house.tableBuilt = false; house.sel = null;
+    return `
+    <div class="grid cols-4" id="env-kpis"></div>
+    <div class="grid cols-3" style="margin-top:18px">
+      <section class="card span-2">
+        <div class="card-head"><div class="card-title"><span class="ico">🕸️</span> Zone adjacency — the thermal model</div>
+          <div class="legend" id="env-legend"></div></div>
+        <div class="chart tall" id="env-graph"></div>
+        <div class="card-sub">node size = air volume · colour = live temperature · edge = boundary (width ∝ area). Click a zone or edge to inspect.</div>
+      </section>
+      <section class="card">
+        <div class="card-head"><div class="card-title"><span class="ico">🧱</span> Boundary detail</div></div>
+        <div id="env-detail" class="faint">Pick a boundary in the graph or the table to see its construction, U-value and orientation.</div>
+      </section>
+    </div>
+    <div class="grid cols-2" style="margin-top:18px">
+      <section class="card">
+        <div class="card-head"><div class="card-title"><span class="ico">📉</span> Where the house loses heat — now</div>
+          <div class="card-sub">conductive loss = area × U × ΔT (exterior + ground)</div></div>
+        <div class="chart" id="env-loss"></div>
+      </section>
+      <section class="card">
+        <div class="card-head"><div class="card-title"><span class="ico">📋</span> Boundaries</div><div class="card-sub" id="env-count"></div></div>
+        <div class="env-table-wrap"><table class="env-table" id="env-table"></table></div>
+      </section>
+    </div>
+    <section class="card span-full" style="margin-top:18px">
+      <div class="card-head"><div class="card-title"><span class="ico">🌡️</span> Per-zone heat balance — now</div><div class="card-sub" id="env-sun"></div></div>
+      <div class="env-zone-grid" id="env-zones"></div>
+    </section>`;
+  },
+  update(store) {
+    const topo = store['/api/model/topology']?.data;
+    if (!topo) { $('#env-detail').textContent = 'Model topology unavailable.'; return; }
+    const temps = {}; (store['/api/state']?.data?.zones || []).forEach((z) => { temps[z.zone] = z.temp_c; });
+    house.topo = topo; house.temps = temps;
+    house.outside = store['/api/live']?.data?.outside_temp_c ?? null;
+    house.ground = topo.ground_temperature_c ?? null; // configured slab/ground boundary temperature
+    house.solar = {}; (store['/api/model/solar']?.data?.boundaries || []).forEach((b) => { house.solar[b.id] = b.solar_w; });
+    house.sun = store['/api/model/solar']?.data?.sun || null;
+    house.comfort = {}; (store['/api/zones']?.data || []).forEach((z) => { house.comfort[z.zone] = z; });
+
+    this.kpis();
+    this.graph();
+    this.loss();
+    this.zoneBalance();
+    if (!house.tableBuilt) { this.table(); house.tableBuilt = true; }
+    $('#env-legend').innerHTML = Object.values(KIND).map((k) => `<span><i style="background:${k.color}33;border:1px solid ${k.color}"></i>${k.label}</span>`).join('');
+    this.renderDetail();
+  },
+  // --- envelope = boundaries that touch outside/ground (the real heat-loss surfaces) ---
+  envBoundaries() { return house.topo.boundaries.filter((b) => b.kind !== 'interior'); },
+  zoneTemp(name) { return name === 'outside' ? house.outside : name === 'ground' ? house.ground : (house.temps[name] ?? null); },
+  // ΔT for an envelope loss: the interior zone vs the outside/ground it faces (null for interior).
+  lossDeltaT(b) {
+    if (b.kind === 'interior') return null;
+    const z = b.zone_a === 'outside' || b.zone_a === 'ground' ? b.zone_b : b.zone_a;
+    const ti = this.zoneTemp(z), to = b.kind === 'ground' ? house.ground : house.outside;
+    return (ti == null || to == null) ? null : ti - to;
+  },
+  lossW(b) { const dt = this.lossDeltaT(b); return dt == null ? null : Math.max(0, b.ua * dt); },
+  // Surface-absorbed solar load now (W) — opaque exterior surfaces only; not direct room heat.
+  solarW(b) { return house.solar[b.id] || 0; },
+  // Signed conductive flow across an INTERIOR boundary now (W): + = zone_a → zone_b.
+  interFlow(b) {
+    if (b.kind !== 'interior') return null;
+    const ta = this.zoneTemp(b.zone_a), tb = this.zoneTemp(b.zone_b);
+    return (ta == null || tb == null) ? null : b.ua * (ta - tb);
+  },
+  kpis() {
+    const env = this.envBoundaries();
+    const area = env.reduce((s, b) => s + b.area_m2, 0);
+    const ua = env.reduce((s, b) => s + b.ua, 0);
+    const meanU = area > 0 ? ua / area : null;
+    const worst = env.reduce((m, b) => (b.u_value > (m?.u_value ?? -1) ? b : m), null);
+    // The dominant losses are to outside (walls/roof), so a figure is only complete with the live
+    // outdoor temperature — otherwise we'd show a misleading ground-only partial as the whole.
+    const haveLoss = house.outside != null && env.some((b) => this.lossW(b) != null);
+    const liveLoss = env.map((b) => this.lossW(b)).filter((x) => x != null).reduce((s, x) => s + x, 0);
+    const liveSolar = env.reduce((s, b) => s + this.solarW(b), 0);
+    const kpi = (label, val, sub) => `<section class="card"><div class="kpi"><div class="kpi-label">${label}</div><div class="kpi-value">${val}</div><div class="kpi-sub">${sub}</div></div></section>`;
+    $('#env-kpis').innerHTML = [
+      kpi('Insulation grade', `<span style="color:${uColor(meanU)}">${heatGrade(meanU)}</span><span class="unit"> U ${fmt.n(meanU, 2)}</span>`, 'area-weighted envelope U'),
+      kpi('Heat-loss coefficient', `${fmt.n(ua, 0)}<span class="unit">W/K</span>`, `${fmt.n(area, 0)} m² · ${env.length} surfaces`),
+      kpi('Heat loss now', haveLoss ? `${fmt.n(liveLoss / 1000, 2)}<span class="unit">kW</span>` : '—', haveLoss ? (liveSolar > 1 ? `☀ ${fmt.n(liveSolar / 1000, 1)} kW sun on surfaces` : 'conductive, through the envelope') : 'waiting for outdoor temperature'),
+      kpi('Leakiest surface', worst ? `<span style="color:${uColor(worst.u_value)}">${fmt.n(worst.u_value, 2)}</span><span class="unit">U</span>` : '—', worst ? nice(worst.type_name) : '—'),
+    ].join('');
+  },
+  zoneBalance() {
+    const el = $('#env-zones'); if (!el) return;
+    if (house.sun) $('#env-sun').textContent = house.sun.up ? `☀ sun ${Math.round(house.sun.elevation_deg)}° up, ${compassDir(house.sun.azimuth_deg)}` : '🌙 sun below horizon';
+    const interior = house.topo.zones.filter((z) => z.role === 'interior' && z.volume_m3);
+    const cards = interior.map((z) => {
+      const bs = house.topo.boundaries.filter((b) => (b.zone_a === z.name || b.zone_b === z.name) && b.kind !== 'interior');
+      const ua = bs.reduce((s, b) => s + b.ua, 0);
+      const loss = bs.map((b) => this.lossW(b)).filter((x) => x != null).reduce((s, x) => s + x, 0);
+      const solar = bs.reduce((s, b) => s + this.solarW(b), 0);
+      const ti = house.temps[z.name];
+      const cf = house.comfort[z.name];
+      const band = cf && ti != null ? (ti < cf.t_min ? ['blue', 'cool'] : ti > cf.t_max ? ['red', 'warm'] : ['green', 'comfort']) : null;
+      const dom = bs.slice().sort((a, b) => (this.lossW(b) || 0) - (this.lossW(a) || 0))[0];
+      return `<div class="env-zone" data-z="${esc(z.name)}">
+        <div class="env-zone-head"><span class="env-zone-name">${nice(z.name)}</span>${band ? `<span class="badge ${band[0]}">${band[1]}</span>` : ''}</div>
+        <div class="env-zone-temp" style="color:${tempColor(ti)}">${fmt.temp(ti)}<span class="env-zone-band">${cf ? ` / ${fmt.n(cf.t_min, 0)}–${fmt.n(cf.t_max, 0)}°` : ''}</span></div>
+        <div class="env-zone-row"><span>UA to outside</span><span>${fmt.n(ua, 1)} W/K</span></div>
+        <div class="env-zone-row"><span>loss now</span><span style="color:${css('--red')}">${(ti == null || house.outside == null) ? '—' : `${fmt.n(loss, 0)} W`}</span></div>
+        ${solar > 1 ? `<div class="env-zone-row"><span>☀ on surfaces</span><span>${fmt.n(solar, 0)} W</span></div>` : ''}
+        ${dom ? `<div class="env-zone-dom faint">biggest path: ${nice(dom.zone_a === z.name ? dom.zone_b : dom.zone_a)} · ${esc(dom.kind)} · ${fmt.n(dom.ua, 1)} W/K</div>` : ''}
+      </div>`;
+    });
+    el.innerHTML = cards.join('') || '<div class="faint">No heated zones with boundaries.</div>';
+    el.querySelectorAll('.env-zone').forEach((c) => { c.onclick = () => { house.sel = { zone: c.dataset.z }; screens.house.renderDetail(); }; });
+  },
+  graph() {
+    const c = chart('env-graph'); if (!c) return;
+    const t = house.topo;
+    const vols = t.zones.map((z) => z.volume_m3 || 0);
+    const vmax = Math.max(1, ...vols);
+    const nodes = t.zones.map((z) => ({
+      name: z.name, value: z.volume_m3,
+      symbolSize: z.role === 'interior' ? 12 + 34 * Math.sqrt((z.volume_m3 || 0) / vmax) : 40,
+      symbol: z.role === 'interior' ? 'circle' : 'roundRect',
+      itemStyle: { color: z.role === 'interior' ? tempColor(house.temps[z.name]) : (z.role === 'ground' ? '#6b5436' : '#27406a'), borderColor: css('--border'), borderWidth: 1 },
+      label: { show: true, color: css('--text'), fontSize: 10, formatter: nice(z.name) },
+    }));
+    // Aggregate boundaries into one edge per zone-pair (sum area; the most-exterior kind dominates).
+    const rank = { exterior: 3, roof: 3, ground: 2, interior: 1 };
+    const agg = new Map();
+    for (const b of t.boundaries) {
+      const key = [b.zone_a, b.zone_b].sort().join(' ');
+      const e = agg.get(key) || { source: b.zone_a, target: b.zone_b, area: 0, kind: 'interior', ids: [] };
+      e.area += b.area_m2; e.ids.push(b.id);
+      if (rank[b.kind] > rank[e.kind]) e.kind = b.kind;
+      agg.set(key, e);
+    }
+    const amax = Math.max(1, ...[...agg.values()].map((e) => e.area));
+    const links = [...agg.values()].map((e) => {
+      const k = kindOf(e.kind);
+      return {
+        source: e.source, target: e.target, ids: e.ids,
+        lineStyle: { color: k.color, width: 1 + 6 * Math.sqrt(e.area / amax), opacity: e.kind === 'interior' ? 0.35 : 0.85, type: k.dash ? 'dashed' : 'solid', curveness: 0.12 },
+      };
+    });
+    // "Built" is tied to the live ECharts instance (a theme toggle disposes it without re-mounting),
+    // so check the instance for the graph series rather than a module flag that would outlive it.
+    const opt = c.getOption();
+    const built = opt && Array.isArray(opt.series) && opt.series.some((s) => s.type === 'graph');
+    if (!built) {
+      c.setOption({
+        tooltip: {
+          trigger: 'item', confine: true, backgroundColor: css('--surface-2'), borderColor: css('--border'), textStyle: { color: css('--text') },
+          formatter: (p) => p.dataType === 'edge'
+            ? `${nice(p.data.source)} ↔ ${nice(p.data.target)}<br>${p.data.ids.length} boundary(ies)`
+            : `${nice(p.name)}${p.value ? `<br>${fmt.n(p.value, 0)} m³ · ${fmt.temp(house.temps[p.name])}` : ''}`,
+        },
+        series: [{
+          type: 'graph', layout: 'force', roam: true, draggable: true,
+          force: { repulsion: 220, edgeLength: [40, 140], gravity: 0.12 },
+          emphasis: { focus: 'adjacency', lineStyle: { width: 6 } },
+          data: nodes, links, lineStyle: { color: 'source' },
+        }],
+      }, true);
+      c.off('click');
+      c.on('click', (p) => {
+        if (p.dataType === 'edge') { const id = p.data.ids.slice().sort((a, b) => house.topo.boundaries[b].area_m2 - house.topo.boundaries[a].area_m2)[0]; house.sel = id; screens.house.renderDetail(); }
+        else if (p.dataType === 'node') { house.sel = { zone: p.name }; screens.house.renderDetail(); }
+      });
+    } else {
+      // recolour nodes live (positions kept; merge, not replace)
+      c.setOption({ series: [{ data: nodes }] });
+    }
+  },
+  loss() {
+    const c = chart('env-loss'); if (!c) return;
+    // Need the live outdoor temperature for a complete picture (walls/roof dominate); without it,
+    // show the waiting state rather than a misleading ground-only ranking.
+    const rows = house.outside == null ? []
+      : this.envBoundaries().map((b) => ({ b, w: this.lossW(b) })).filter((r) => r.w != null)
+        .sort((a, z) => z.w - a.w).slice(0, 10).reverse();
+    const labels = rows.map((r) => `${nice(r.b.zone_a === 'outside' || r.b.zone_a === 'ground' ? r.b.zone_b : r.b.zone_a)} · ${esc(r.b.kind)}`);
+    c.setOption(Object.assign(baseOption(), {
+      grid: { left: 8, right: 40, top: 10, bottom: 20, containLabel: true },
+      tooltip: { trigger: 'axis', confine: true, valueFormatter: (v) => `${Math.round(v)} W` },
+      xAxis: { type: 'value', name: 'W', axisLabel: { color: css('--muted') }, splitLine: { lineStyle: { color: css('--surface-2') } } },
+      yAxis: { type: 'category', data: labels, axisLabel: { color: css('--muted'), fontSize: 10 } },
+      series: [{ type: 'bar', data: rows.map((r) => Math.round(r.w)), itemStyle: { color: css('--red'), borderRadius: [0, 4, 4, 0] }, barWidth: '62%', label: { show: true, position: 'right', color: css('--muted'), formatter: (p) => `${p.value} W` } }],
+    }), true);
+    if (!rows.length) c.setOption({ graphic: { type: 'text', left: 'center', top: 'middle', style: { text: 'waiting for live indoor/outdoor temperatures…', fill: css('--faint') } } });
+  },
+  table() {
+    const head = [['type_name', 'Boundary'], ['kind', 'Kind'], ['area_m2', 'Area'], ['u_value', 'U'], ['azimuth_deg', 'Facing'], ['ua', 'UA']];
+    const render = () => {
+      const { key, dir } = house.sort;
+      const rows = house.topo.boundaries.slice().sort((a, b) => {
+        const va = a[key], vb = b[key];
+        if (va == null) return 1; if (vb == null) return -1;
+        return (va > vb ? 1 : va < vb ? -1 : 0) * dir;
+      });
+      const th = head.map(([k, lbl]) => `<th data-k="${k}" class="${house.sort.key === k ? 'sorted ' + (dir < 0 ? 'desc' : 'asc') : ''}">${lbl}</th>`).join('');
+      const tr = rows.map((b) => `<tr data-id="${b.id}" class="${house.sel === b.id ? 'sel' : ''}">
+        <td>${nice(b.zone_a)} ↔ ${nice(b.zone_b)}<div class="faint" style="font-size:.72rem">${nice(b.type_name)}</div></td>
+        <td><span class="env-pill" style="background:${kindOf(b.kind).color}22;color:${kindOf(b.kind).color}">${esc(b.kind)}</span></td>
+        <td class="num">${fmt.n(b.area_m2, 1)}</td>
+        <td class="num" style="color:${uColor(b.u_value)};font-weight:700">${fmt.n(b.u_value, 2)}</td>
+        <td class="num">${b.azimuth_deg == null ? '—' : compassDir(b.azimuth_deg)}</td>
+        <td class="num">${fmt.n(b.ua, 1)}</td></tr>`).join('');
+      $('#env-table').innerHTML = `<thead><tr>${th}</tr></thead><tbody>${tr}</tbody>`;
+      $('#env-count').textContent = `${rows.length} boundaries`;
+      $('#env-table').querySelectorAll('th').forEach((el) => el.onclick = () => {
+        const k = el.dataset.k; house.sort = { key: k, dir: house.sort.key === k ? -house.sort.dir : -1 }; render();
+      });
+      $('#env-table').querySelectorAll('tbody tr').forEach((el) => el.onclick = () => { house.sel = +el.dataset.id; render(); screens.house.renderDetail(); });
+    };
+    house._renderTable = render; render();
+  },
+  renderDetail() {
+    const el = $('#env-detail'); if (!el) return;
+    const sel = house.sel;
+    if (sel == null) return;
+    if (typeof sel === 'object' && sel.zone) { if (house._renderTable) house._renderTable(); el.innerHTML = this.zoneDetail(sel.zone); return; }
+    const b = house.topo.boundaries[sel]; if (!b) return;
+    if (house._renderTable) house._renderTable(); // keep the table's selected-row highlight in sync
+    el.innerHTML = this.boundaryDetail(b);
+  },
+  zoneDetail(name) {
+    const z = house.topo.zones.find((x) => x.name === name) || {};
+    const bs = house.topo.boundaries.filter((b) => b.zone_a === name || b.zone_b === name).sort((a, b) => b.area_m2 - a.area_m2);
+    const t = house.temps[name];
+    const rows = bs.map((b) => `<div class="stat-row"><span class="k">${nice(b.zone_a === name ? b.zone_b : b.zone_a)} <span class="env-pill" style="background:${kindOf(b.kind).color}22;color:${kindOf(b.kind).color}">${esc(b.kind)}</span></span><span class="v">${fmt.n(b.area_m2, 1)} m² · U ${fmt.n(b.u_value, 2)}</span></div>`).join('');
+    return `<div class="env-d-head"><span class="env-d-ico" style="color:${tempColor(t)}">${z.role === 'interior' ? '🏠' : z.role === 'ground' ? '⛰️' : '🌳'}</span><div><div class="env-d-title">${nice(name)}</div><div class="faint">${z.volume_m3 ? fmt.n(z.volume_m3, 0) + ' m³' : 'infinite reservoir'} · now ${fmt.temp(t)}</div></div></div>
+      <div class="env-d-sub">${bs.length} boundaries</div>${rows}`;
+  },
+  boundaryDetail(b) {
+    const compass = b.azimuth_deg == null ? '' : (() => {
+      const a = (b.azimuth_deg % 360) * Math.PI / 180, x = 19 + 15 * Math.sin(a), y = 19 - 15 * Math.cos(a);
+      return `<svg width="40" height="40" viewBox="0 0 38 38" class="env-compass"><circle cx="19" cy="19" r="17" fill="none" stroke="${css('--border')}"/><line x1="19" y1="19" x2="${x.toFixed(1)}" y2="${y.toFixed(1)}" stroke="${css('--amber')}" stroke-width="2"/><circle cx="19" cy="19" r="2" fill="${css('--amber')}"/></svg>`;
+    })();
+    const interior = b.kind === 'interior';
+    const flow = this.interFlow(b);
+    const facts = [
+      ['Between', `${nice(b.zone_a)} ↔ ${nice(b.zone_b)}`],
+      ['Area', `${fmt.n(b.area_m2, 2)} m²`],
+      ['U-value', `<span style="color:${uColor(b.u_value)};font-weight:700">${fmt.n(b.u_value, 3)}</span> W/m²K · grade ${heatGrade(b.u_value)}`],
+      ['R-value', `${fmt.n(b.r_value, 2)} m²K/W`],
+      !interior && this.lossW(b) != null ? ['Heat loss now', `${Math.round(this.lossW(b))} W (ΔT ${fmt.n(this.lossDeltaT(b), 1)} K)`] : null,
+      !interior && this.solarW(b) > 0.5 ? ['Solar load now', `${Math.round(this.solarW(b))} W absorbed on the surface`] : null,
+      interior && flow != null ? ['Flow between zones', `<span style="color:${css('--amber')}">${nice(flow >= 0 ? b.zone_a : b.zone_b)} → ${nice(flow >= 0 ? b.zone_b : b.zone_a)} · ${Math.round(Math.abs(flow))} W</span>`] : null,
+      b.azimuth_deg != null ? ['Facing', `${Math.round(b.azimuth_deg)}° ${compassDir(b.azimuth_deg)}${b.tilt_deg != null ? ` · tilt ${Math.round(b.tilt_deg)}°` : ''}`] : null,
+      b.solar_absorptance != null ? ['Solar absorptance', fmt.n(b.solar_absorptance, 2)] : null,
+    ].filter(Boolean);
+    return `<div class="env-d-head"><span class="env-d-ico" style="color:${kindOf(b.kind).color}">🧱</span>
+        <div><div class="env-d-title">${nice(b.type_name)}</div><div class="faint">${esc(b.kind)} boundary</div></div>${compass}</div>
+      ${this.crossSection(b)}
+      <div class="env-d-facts">${facts.map(([k, v]) => `<div class="stat-row"><span class="k">${k}</span><span class="v">${v}</span></div>`).join('')}</div>`;
+  },
+  crossSection(b) {
+    if (!b.layers || !b.layers.length) {
+      return `<div class="env-xsec-simple faint">Simple boundary — modelled as a single U/g pane (no layered construction)${b.u_value > 10 ? '; the high U marks an open/virtual connection between zones.' : '.'}</div>`;
+    }
+    // Layers are stored zones[0]→zones[1]. Orient them so the OUTER (outside/ground) side is on the
+    // left and the inner (room) side on the right — reversing when the exterior zone is zones[1] — so
+    // the end labels and the underfloor-heating 🔥 marker land on the physically correct end (floors,
+    // roofs and inter-floor slabs are authored room-side-first, the opposite of exterior walls).
+    const isExt = (z) => z === 'outside' || z === 'ground';
+    const reverse = isExt(b.zone_b) && !isExt(b.zone_a);
+    const layers = reverse ? b.layers.slice().reverse() : b.layers;
+    const outerName = reverse ? b.zone_b : b.zone_a;
+    const innerName = reverse ? b.zone_a : b.zone_b;
+    const tot = layers.reduce((s, l) => s + Math.max(l.thickness_mm, 4), 0);
+    const segs = layers.map((l) => {
+      const w = (Math.max(l.thickness_mm, 4) / tot * 100).toFixed(2);
+      const mk = l.marker ? ` env-marker` : '';
+      const fire = l.marker === 'heating' ? '<span class="env-fire">🔥</span>' : '';
+      return `<div class="env-layer${mk}" style="width:${w}%;background:${layerColor(l.conductivity)}" title="${nice(l.material)} — ${fmt.n(l.thickness_mm, 0)} mm, λ ${fmt.n(l.conductivity, 3)}">${fire}<span class="env-layer-lbl">${fmt.n(l.thickness_mm, 0)}</span></div>`;
+    }).join('');
+    const legend = layers.map((l) => `<div class="env-leg-row"><i style="background:${layerColor(l.conductivity)}"></i>${nice(l.material)}<span class="faint"> · ${fmt.n(l.thickness_mm, 0)} mm · λ ${fmt.n(l.conductivity, 3)}${l.marker ? ` · ${nice(l.marker)}` : ''}</span></div>`).join('');
+    return `<div class="env-xsec"><div class="env-xsec-bars">${segs}</div><div class="env-xsec-ends"><span>${nice(outerName)}</span><span>${nice(innerName)}</span></div></div><div class="env-xsec-legend">${legend}</div>`;
   },
 };
 

--- a/src/dashboard/style.css
+++ b/src/dashboard/style.css
@@ -255,3 +255,56 @@ a.link:hover { text-decoration: underline; }
 
 .skeleton { background: linear-gradient(90deg, var(--surface-2), var(--surface-3), var(--surface-2)); background-size: 200% 100%; animation: shimmer 1.4s infinite; border-radius: 6px; color: transparent; }
 @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+
+/* ---------- House / envelope screen ---------- */
+.env-table-wrap { max-height: 360px; overflow: auto; }
+.env-table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+.env-table th {
+  position: sticky; top: 0; background: var(--surface); text-align: left; color: var(--muted);
+  font-weight: 600; padding: 7px 8px; border-bottom: 1px solid var(--border); cursor: pointer;
+  white-space: nowrap; user-select: none;
+}
+.env-table th:hover { color: var(--text); }
+.env-table th.sorted::after { content: ' ▾'; color: var(--blue); }
+.env-table th.sorted.asc::after { content: ' ▴'; }
+.env-table td { padding: 6px 8px; border-bottom: 1px solid var(--surface-2); vertical-align: top; }
+.env-table td.num { text-align: right; font-variant-numeric: tabular-nums; font-family: var(--mono); }
+.env-table tbody tr { cursor: pointer; transition: background 0.12s; }
+.env-table tbody tr:hover { background: var(--surface-2); }
+.env-table tbody tr.sel { background: var(--blue-soft); box-shadow: inset 3px 0 0 var(--blue); }
+.env-pill { font-size: 0.68rem; font-weight: 700; padding: 1px 7px; border-radius: 999px; white-space: nowrap; }
+
+.env-d-head { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
+.env-d-ico { font-size: 1.7rem; line-height: 1; filter: drop-shadow(0 0 8px currentColor); }
+.env-d-title { font-weight: 700; font-size: 0.98rem; }
+.env-d-sub { color: var(--faint); font-size: 0.78rem; margin: 8px 0 4px; }
+.env-d-facts { margin-top: 12px; }
+.env-compass { margin-left: auto; }
+
+.env-xsec { margin: 6px 0 4px; }
+.env-xsec-bars { display: flex; height: 66px; border-radius: 8px; overflow: hidden; border: 1px solid var(--border); }
+.env-layer {
+  position: relative; min-width: 6px; display: flex; align-items: flex-end; justify-content: center;
+  border-right: 1px solid rgba(0,0,0,0.25); transition: width 0.3s;
+}
+.env-layer:last-child { border-right: none; }
+.env-layer-lbl { font-size: 0.62rem; color: rgba(255,255,255,0.92); padding-bottom: 3px; font-variant-numeric: tabular-nums; text-shadow: 0 1px 2px rgba(0,0,0,0.6); }
+.env-layer.env-marker { box-shadow: inset 0 0 0 2px var(--red); }
+.env-fire { position: absolute; top: 3px; left: 50%; transform: translateX(-50%); font-size: 0.8rem; }
+.env-xsec-ends { display: flex; justify-content: space-between; font-size: 0.68rem; color: var(--faint); margin-top: 3px; }
+.env-xsec-legend { margin-top: 10px; display: flex; flex-direction: column; gap: 4px; }
+.env-leg-row { font-size: 0.76rem; display: flex; align-items: center; gap: 7px; }
+.env-leg-row i { width: 11px; height: 11px; border-radius: 3px; flex: none; }
+.env-xsec-simple { padding: 14px 0; font-size: 0.86rem; line-height: 1.5; }
+
+/* per-zone heat balance */
+.env-zone-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(190px, 1fr)); gap: 12px; }
+.env-zone { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 12px 13px; cursor: pointer; transition: border-color 0.12s, transform 0.12s; }
+.env-zone:hover { border-color: var(--blue); transform: translateY(-1px); }
+.env-zone-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
+.env-zone-name { font-weight: 700; font-size: 0.9rem; }
+.env-zone-temp { font-size: 1.5rem; font-weight: 700; font-variant-numeric: tabular-nums; line-height: 1.1; margin-bottom: 8px; }
+.env-zone-band { font-size: 0.74rem; color: var(--faint); font-weight: 500; }
+.env-zone-row { display: flex; justify-content: space-between; font-size: 0.78rem; padding: 2px 0; color: var(--muted); }
+.env-zone-row span:last-child { font-weight: 600; color: var(--text); font-variant-numeric: tabular-nums; }
+.env-zone-dom { margin-top: 6px; font-size: 0.72rem; border-top: 1px solid var(--surface-3); padding-top: 6px; }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod solar_forecast;
 mod source;
 mod state_space;
 mod tools;
+mod topology;
 mod validate;
 mod web;
 
@@ -46,10 +47,13 @@ async fn main() -> anyhow::Result<()> {
     let model = Model::load("model.json5")?;
     let rcnet: RcNetwork = (&model).into();
     let ss: StateSpace = (&rcnet).into();
+    // Plain (Rc-free) envelope snapshot for the read-only `/api/model/topology` endpoint, taken while
+    // `model` is still alive (it is dropped once `rcnet`/`ss` are built).
+    let topology = crate::topology::ModelTopology::from(&model);
 
     let args: Vec<String> = std::env::args().collect();
     if args.iter().any(|a| a == "serve") {
-        return run_server(rcnet, ss).await;
+        return run_server(rcnet, ss, topology).await;
     }
     // `... backtest-heating <start-rfc3339> <stop-rfc3339>` validates the heat model under active
     // heating, driving it with the recorded per-zone relays over an explicit (e.g. winter) window.
@@ -361,7 +365,11 @@ async fn run_backtest_heating(
 }
 
 /// Start the read-only monitoring HTTP API.
-async fn run_server(rcnet: RcNetwork, ss: StateSpace) -> anyhow::Result<()> {
+async fn run_server(
+    rcnet: RcNetwork,
+    ss: StateSpace,
+    topology: crate::topology::ModelTopology,
+) -> anyhow::Result<()> {
     let config = optimize::config::ControlConfig::load("config.json5")?;
     let db = SourceClients::with_signals(
         InfluxDB::from_config("config.json5")?,
@@ -372,7 +380,7 @@ async fn run_server(rcnet: RcNetwork, ss: StateSpace) -> anyhow::Result<()> {
     let longitude = Angle::new::<degree>(config.site.longitude);
     let tick = std::time::Duration::from_secs(config.mpc_tick_minutes.max(1) * 60);
     web::serve(
-        web::AppState::new(rcnet, ss, config, db, latitude, longitude),
+        web::AppState::new(rcnet, ss, topology, config, db, latitude, longitude),
         3000,
         tick,
     )

--- a/src/tools/sun.rs
+++ b/src/tools/sun.rs
@@ -98,6 +98,22 @@ pub fn calculate_tilted_irradiance(
     tilted_irradiance.max(watts_per_square_meter(0.0))
 }
 
+/// The sun's current position at `latitude`/`longitude`: `(azimuth°, elevation°)`, where elevation is
+/// degrees above the horizon (negative when the sun is down).
+pub fn sun_azimuth_elevation(
+    latitude: Angle,
+    longitude: Angle,
+    datetime: &DateTime<Utc>,
+) -> (f64, f64) {
+    let p = spa::calc_solar_position(
+        *datetime,
+        latitude.get::<degree>(),
+        longitude.get::<degree>(),
+    )
+    .unwrap();
+    (p.azimuth, 90.0 - p.zenith_angle)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -1,0 +1,240 @@
+//! A plain, serializable snapshot of the building model's **thermal envelope** — every zone and the
+//! boundaries between them, with area, orientation, construction (layer stack), and U-value.
+//!
+//! Like [`crate::rc_network::RcNetwork`], this holds **no `Rc`**: it is extracted from [`Model`] once
+//! at startup so the read-only web layer can serve `/api/model/topology` from `Send + Sync` state,
+//! without plumbing the `Rc`-laden `Model` itself across the axum handlers.
+
+use serde::Serialize;
+use uom::si::heat_transfer::watt_per_square_meter_kelvin;
+use uom::si::{
+    angle::degree, area::square_meter, length::meter, length::millimeter,
+    thermal_conductivity::watt_per_meter_kelvin, volume::cubic_meter,
+};
+
+use crate::model::{BoundaryType, Model};
+
+/// ISO 6946 surface-film resistances (m²K/W) for a boundary `kind`: `(interior, exterior)`. Adding
+/// them to the layer stack gives the conventional U-value (a film-free conductance over-states U).
+fn surface_films(kind: &str) -> (f64, f64) {
+    match kind {
+        "exterior" | "roof" => (0.13, 0.04), // Rsi + Rse
+        "ground" => (0.13, 0.0),             // interior film only; the ground side has no air film
+        _ => (0.13, 0.13),                   // interior boundary: a film each side
+    }
+}
+
+/// The whole envelope: zones (nodes) and boundaries (edges).
+#[derive(Clone, Debug, Serialize)]
+pub struct ModelTopology {
+    pub zones: Vec<ZoneInfo>,
+    pub boundaries: Vec<BoundaryInfo>,
+}
+
+/// One thermal zone (a room, or a reserved reservoir).
+#[derive(Clone, Debug, Serialize)]
+pub struct ZoneInfo {
+    pub name: String,
+    /// Air volume (m³); `None` for the reserved infinite-capacity reservoirs (`outside`/`ground`).
+    pub volume_m3: Option<f64>,
+    /// `interior` | `outside` | `ground`.
+    pub role: String,
+}
+
+/// One boundary (a wall / floor / ceiling / roof) between two zones.
+#[derive(Clone, Debug, Serialize)]
+pub struct BoundaryInfo {
+    pub id: usize,
+    pub zone_a: String,
+    pub zone_b: String,
+    pub area_m2: f64,
+    /// Compass azimuth of an exterior surface (°); `None` for interior boundaries.
+    pub azimuth_deg: Option<f64>,
+    /// Tilt from horizontal (°); 90 = vertical wall, 0 = flat roof/floor.
+    pub tilt_deg: Option<f64>,
+    /// `interior` | `exterior` | `roof` | `ground`.
+    pub kind: String,
+    pub type_name: String,
+    /// Thermal transmittance (W/m²K) and its reciprocal resistance (m²K/W).
+    pub u_value: f64,
+    pub r_value: f64,
+    /// Conductive loss coefficient = area × U (W/K) — drives the heat-loss ranking.
+    pub ua: f64,
+    /// Fraction of incident solar absorbed at the outer surface (`Layered` only).
+    pub solar_absorptance: Option<f64>,
+    /// Layer stack in the model's `zones[0]`→`zones[1]` order (exterior-first for walls, room-first
+    /// for floors/roofs/inter-floor slabs — so a consumer must orient it, as the dashboard does);
+    /// `None` for a `Simple` U/g boundary.
+    pub layers: Option<Vec<LayerInfo>>,
+    /// An addressable interface authored at the zone↔first-layer surface (`Layered.initial_marker`),
+    /// distinct from a layer's trailing marker; `None` when absent.
+    pub initial_marker: Option<String>,
+}
+
+/// One material layer within a [`BoundaryInfo`].
+#[derive(Clone, Debug, Serialize)]
+pub struct LayerInfo {
+    pub material: String,
+    pub thickness_mm: f64,
+    /// Thermal conductivity λ (W/mK).
+    pub conductivity: f64,
+    /// The addressable interface after this layer (e.g. the underfloor `heating` slab marker).
+    pub marker: Option<String>,
+}
+
+fn role(name: &str) -> &'static str {
+    match name {
+        "outside" => "outside",
+        "ground" => "ground",
+        _ => "interior",
+    }
+}
+
+impl From<&Model> for ModelTopology {
+    fn from(model: &Model) -> Self {
+        let mut zones: Vec<ZoneInfo> = model
+            .zones
+            .values()
+            .map(|z| ZoneInfo {
+                name: z.name.clone(),
+                volume_m3: z.volume.map(|v| v.get::<cubic_meter>()),
+                role: role(&z.name).to_string(),
+            })
+            .collect();
+        zones.sort_by(|a, b| a.name.cmp(&b.name));
+
+        let boundaries = model
+            .boundaries
+            .iter()
+            .enumerate()
+            .map(|(id, b)| {
+                let area_m2 = b.area.get::<square_meter>();
+                let za = b.zones[0].name.clone();
+                let zb = b.zones[1].name.clone();
+                let touches = |n: &str| za == n || zb == n;
+                let tilt_deg = b.tilt.map(|t| t.get::<degree>());
+                // A surface touching `outside` is a roof if it's notably off-vertical (a pitched roof
+                // sits ~30-50° from horizontal; walls/gables are ~90°), else an exterior wall.
+                let kind = if touches("ground") {
+                    "ground"
+                } else if touches("outside") {
+                    match tilt_deg {
+                        Some(t) if t < 60.0 => "roof",
+                        _ => "exterior",
+                    }
+                } else {
+                    "interior"
+                };
+                let (rsi, rse) = surface_films(kind);
+
+                let (type_name, u_value, solar_absorptance, layers, initial_marker) =
+                    match &*b.boundary_type {
+                        // A `Simple` U/g pane's `u` is the conventional U-value (films included).
+                        BoundaryType::Simple { name, u, .. } => (
+                            name.clone(),
+                            u.get::<watt_per_square_meter_kelvin>(),
+                            None,
+                            None,
+                            None,
+                        ),
+                        BoundaryType::Layered {
+                            name,
+                            layers,
+                            solar_absorptance,
+                            initial_marker,
+                        } => {
+                            // Conventional U: 1 / (Rsi + Σ thickness/λ + Rse) with ISO 6946 films — the
+                            // U-value people expect. (The RC model uses its own air-convection coefficient
+                            // internally, so its node conductances differ slightly from this display U.)
+                            let r_layers: f64 = layers
+                                .iter()
+                                .map(|l| {
+                                    l.thickness.get::<meter>()
+                                        / l.material
+                                            .thermal_conductivity
+                                            .get::<watt_per_meter_kelvin>()
+                                })
+                                .sum();
+                            let r_total = rsi + r_layers + rse;
+                            let u = if r_total > 0.0 { 1.0 / r_total } else { 0.0 };
+                            let infos = layers
+                                .iter()
+                                .map(|l| LayerInfo {
+                                    material: l.material.name.clone(),
+                                    thickness_mm: l.thickness.get::<millimeter>(),
+                                    conductivity: l
+                                        .material
+                                        .thermal_conductivity
+                                        .get::<watt_per_meter_kelvin>(),
+                                    marker: l.following_marker.clone(),
+                                })
+                                .collect();
+                            (
+                                name.clone(),
+                                u,
+                                Some(*solar_absorptance),
+                                Some(infos),
+                                initial_marker.clone(),
+                            )
+                        }
+                    };
+
+                BoundaryInfo {
+                    id,
+                    zone_a: za,
+                    zone_b: zb,
+                    area_m2,
+                    azimuth_deg: b.azimuth.map(|a| a.get::<degree>()),
+                    tilt_deg,
+                    kind: kind.to_string(),
+                    type_name,
+                    u_value,
+                    r_value: if u_value > 0.0 { 1.0 / u_value } else { 0.0 },
+                    ua: area_m2 * u_value,
+                    solar_absorptance,
+                    layers,
+                    initial_marker,
+                }
+            })
+            .collect();
+
+        ModelTopology { zones, boundaries }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn topology_from_real_model() {
+        let model = Model::load("model.json5").expect("model.json5 loads");
+        let topo = ModelTopology::from(&model);
+
+        // The reserved reservoirs and the real rooms are present.
+        assert!(topo.zones.iter().any(|z| z.role == "outside"));
+        assert!(topo.zones.iter().any(|z| z.role == "ground"));
+        assert!(topo.zones.iter().filter(|z| z.role == "interior").count() > 5);
+
+        // Layered assemblies get a finite, positive U/R; UA is exactly area × U.
+        assert!(!topo.boundaries.is_empty());
+        let layered: Vec<_> = topo
+            .boundaries
+            .iter()
+            .filter(|b| b.layers.is_some())
+            .collect();
+        assert!(!layered.is_empty());
+        assert!(layered
+            .iter()
+            .all(|b| b.u_value.is_finite() && b.u_value > 0.0 && b.r_value > 0.0));
+        for b in &topo.boundaries {
+            assert!((b.ua - b.area_m2 * b.u_value).abs() < 1e-6);
+        }
+
+        // The underfloor-heating marker surfaces on at least one ground-floor slab.
+        assert!(topo.boundaries.iter().any(|b| b
+            .layers
+            .as_ref()
+            .is_some_and(|ls| ls.iter().any(|l| l.marker.as_deref() == Some("heating")))));
+    }
+}

--- a/src/web.rs
+++ b/src/web.rs
@@ -28,6 +28,7 @@ use chrono::{DateTime, Timelike, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uom::si::f64::Angle;
+use uom::si::{angle::degree, f64::Ratio, heat_flux_density::watt_per_square_meter, ratio::ratio};
 
 use crate::app::{
     current_plan, current_state, zone_temp_history, GainsSnapshot, PlanReport, TimestampedPlan,
@@ -37,6 +38,8 @@ use crate::pv_backtest::backtest_pv;
 use crate::rc_network::RcNetwork;
 use crate::source::SourceClients;
 use crate::state_space::StateSpace;
+use crate::tools::sun::{calculate_tilted_irradiance, sun_azimuth_elevation};
+use crate::topology::ModelTopology;
 use crate::validate::{backtest_passive, calibrate_internal_gains, BacktestConfig, ZoneBacktest};
 
 /// How long a computed response stays fresh before it is recomputed.
@@ -48,6 +51,8 @@ const COMPUTE_TIMEOUT: Duration = Duration::from_secs(45);
 pub struct AppState {
     pub net: RcNetwork,
     pub ss: StateSpace,
+    /// Rc-free snapshot of the building envelope (zones + boundaries), for `/api/model/topology`.
+    pub topology: ModelTopology,
     pub config: ControlConfig,
     pub db: SourceClients,
     pub latitude: Angle,
@@ -69,6 +74,7 @@ impl AppState {
     pub fn new(
         net: RcNetwork,
         ss: StateSpace,
+        topology: ModelTopology,
         config: ControlConfig,
         db: SourceClients,
         latitude: Angle,
@@ -77,6 +83,7 @@ impl AppState {
         Self {
             net,
             ss,
+            topology,
             config,
             db,
             latitude,
@@ -264,6 +271,8 @@ async fn api_index() -> Json<Value> {
         { "path": "/", "desc": "the monitoring dashboard (HTML)" },
         { "path": "/api/live", "desc": "measured current telemetry (PV/grid/house/battery/SoC/outside)" },
         { "path": "/api/zones", "desc": "per-zone comfort band + heater limit + internal gain" },
+        { "path": "/api/model/topology", "desc": "building envelope: zones + boundaries (area, orientation, layers, U-value)" },
+        { "path": "/api/model/solar", "desc": "live per-surface clear-sky solar gain (W) + the sun's position" },
         { "path": "/health", "desc": "topology + liveness" },
         { "path": "/livez", "desc": "process liveness (always 200)" },
         { "path": "/readyz", "desc": "readiness: recent plan published" },
@@ -609,6 +618,61 @@ async fn get_zones(State(s): State<Shared>) -> Json<Value> {
     envelope(Utc::now(), 0, Value::Array(zones))
 }
 
+/// The building **envelope** — zones + the boundaries between them with area, orientation,
+/// construction (layer stack), and U-value. Static (built once at startup from the model), so it is
+/// served straight from state with no DB or recompute.
+async fn get_topology(State(s): State<Shared>) -> Json<Value> {
+    let mut data = json!(s.topology);
+    // The configured slab/ground boundary temperature, so the dashboard's ground-loss ΔT uses the
+    // real value rather than a hardcoded constant.
+    data["ground_temperature_c"] = json!(s.config.site.ground_temperature_c);
+    envelope(s.started_at, 0, data)
+}
+
+/// Live per-surface **solar gain**: for each oriented exterior boundary, the clear-sky irradiance now
+/// (W/m²) and the heat it injects (W = irradiance × absorptance × area), plus the sun's position.
+/// Clear-sky (cloud not applied), so it reads the orientation effect — which faces are catching sun.
+async fn get_solar(State(s): State<Shared>) -> Json<Value> {
+    let now = Utc::now();
+    let (az, el) = sun_azimuth_elevation(s.latitude, s.longitude, &now);
+    let boundaries: Vec<Value> = s
+        .topology
+        .boundaries
+        .iter()
+        .filter_map(|b| {
+            let (azimuth, tilt) = (b.azimuth_deg?, b.tilt_deg?);
+            // Only opaque `Layered` surfaces absorb solar in the model; `Simple` panes (windows/doors
+            // that inherit a parent wall's orientation) get none — `solar_absorptance` is `None` for
+            // them, matching the RC network. So `?` here correctly skips them rather than assuming 1.0.
+            let absorptance = b.solar_absorptance?;
+            // And, like the RC network, only surfaces that actually face `outside` receive solar — not
+            // an oriented ground/interior surface (inert today, but keeps the rule identical).
+            if b.zone_a != "outside" && b.zone_b != "outside" {
+                return None;
+            }
+            let irradiance = calculate_tilted_irradiance(
+                s.latitude,
+                s.longitude,
+                &now,
+                Ratio::new::<ratio>(0.0),
+                Angle::new::<degree>(tilt),
+                Angle::new::<degree>(azimuth),
+            )
+            .get::<watt_per_square_meter>();
+            let solar_w = irradiance * absorptance * b.area_m2;
+            Some(json!({ "id": b.id, "irradiance_wm2": irradiance, "solar_w": solar_w }))
+        })
+        .collect();
+    envelope(
+        now,
+        0,
+        json!({
+            "sun": { "azimuth_deg": az, "elevation_deg": el, "up": el > 0.0 },
+            "boundaries": boundaries,
+        }),
+    )
+}
+
 // The dashboard is a self-contained single-page app embedded in the binary (no extra mounts). It
 // reads the JSON API above; ECharts is vendored (not a CDN), so it works fully offline.
 const DASHBOARD_HTML: &str = include_str!("dashboard/index.html");
@@ -652,6 +716,8 @@ pub fn router(state: Shared) -> Router {
         .route("/readyz", get(readyz))
         .route("/api", get(api_index))
         .route("/api/zones", get(get_zones))
+        .route("/api/model/topology", get(get_topology))
+        .route("/api/model/solar", get(get_solar))
         .route("/api/live", get(get_live))
         .route("/api/version", get(version))
         .route("/api/state", get(get_state))


### PR DESCRIPTION
A read-only **House** dashboard tab that makes the building model's thermal envelope legible.

**Backend** (read-only, additive) — an `Rc`-free `ModelTopology` snapshot extracted from the model at startup (mirroring `RcNetwork`):
- `GET /api/model/topology` — zones (volume, role) + boundaries (area, orientation, kind, ISO-6946 U/R-value, UA, solar absorptance, the material layer stack with the underfloor-heating marker) + the configured ground temperature.
- `GET /api/model/solar` — live per-surface clear-sky solar gain + sun position (via `tools/sun.rs`), for opaque exterior surfaces only (matching the RC network's solar rule).

**Frontend** — a zone-adjacency graph (nodes by volume + live temperature, edges by kind/area), a clickable boundary cross-section (orientation-correct layer stack, heating slab highlighted, U/R + compass), an insulation-grade KPI strip with U-colour-graded surfaces, a live heat-loss leaderboard, and a per-zone heat-balance grid.

Read-only + offline (ECharts vendored). `docs/api.md` catalogues both endpoints. **Reviewed across 3 code rounds + a docs round** (13 code + 3 doc findings, all fixed); verified end-to-end with Playwright. 209 tests, clippy + fmt clean.